### PR TITLE
fix: 자동배포 인덱스 누락 수정 (Docker에서 build 실행)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,9 @@ data/_cache/
 # 시험문제 데이터 (출처 불명 → 공개 원격 서버에서 제외)
 data/questions.json
 
+# 인덱스는 이미지 빌드 단계(RUN … build)에서 생성하므로 로컬 산출물은 제외 (항상 재생성)
+data/index.json
+
 # 로컬 전용 스크립트/문서 (원격 이미지에 불필요; sync 도구도 원격판엔 없음)
 alio_sync.py
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ COPY koica_search.py koica_mcp_server.py server_http.py ./
 # 데이터: 검색 인덱스 + 규정 본문. _cache(원본 HWP)/시험범위 PDF는 .dockerignore로 제외
 COPY data/ ./data/
 
+# index.json(검색 인덱스)은 빌드 산출물이라 git·저장소에 없다. 따라서 이미지
+# 빌드 시 extracted → index.json 을 직접 생성한다. 이렇게 해야 로컬 `fly deploy`든
+# GitHub Actions 자동배포(저장소 checkout)든 항상 데이터가 포함된다.
+RUN python3 koica_search.py build
+
 ENV PORT=8080
 EXPOSE 8080
 


### PR DESCRIPTION
## 문제
자동배포된 원격 서버에서 `인덱스 없음. 먼저 'build' 실행: /app/data/index.json` 오류.

## 원인
- `index.json`은 빌드 산출물이라 `.gitignore`로 저장소에 없음
- `Dockerfile`이 build 없이 로컬 `index.json`을 COPY만 함 → 첫 배포(`fly launch`, 로컬)는 통과했으나 자동배포(저장소 checkout)엔 인덱스가 없어 누락

## 수정
- `Dockerfile`: `RUN python3 koica_search.py build` 추가 — `extracted`(149개, git 포함) → `index.json` 이미지 빌드 시 생성
- `.dockerignore`: `data/index.json` 추가 (로컬 산출물 대신 항상 재생성)
- 로컬 재현: build → 6,392 조문 + 1,312 별표·별지 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)