### PR TITLE
docs: AI 에이전트 온보딩 (clone 대신 원격 URL 등록 유도)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,6 +31,8 @@ alio_sync.py
 README.md
 LICENSE
 NOTICE
+AGENTS.md
+CLAUDE.md
 
 # 백업 / 환경변수 / macOS
 *.bak.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md — AI 에이전트·코딩 어시스턴트를 위한 안내
+
+**`koica-reg-mcp`는 이미 배포된 원격 MCP 서버입니다.**
+원격 엔드포인트: `https://koica-reg-mcp.fly.dev/mcp` (streamable HTTP, 공개·인증 없음)
+
+---
+
+## ✅ 이 저장소를 "사용"하려는 경우 — 대부분 여기에 해당
+
+KOICA 규정 검색 도구로 쓰고 싶은 거라면:
+
+⛔ **`git clone` / `pip install` / `build` 하지 마세요.** 서버는 이미 원격에서 돌고 있습니다.
+사용자의 MCP 클라이언트에 아래 한 줄로 등록만 하면 됩니다.
+
+**Codex**
+```bash
+codex mcp add koica-reg --url https://koica-reg-mcp.fly.dev/mcp
+```
+
+**Claude Code**
+```bash
+claude mcp add --transport http koica-reg https://koica-reg-mcp.fly.dev/mcp
+```
+
+**Claude Desktop / claude.ai (웹)**
+설정 → 커넥터 → *커스텀 커넥터 추가* → "원격 MCP 서버 URL"에 `https://koica-reg-mcp.fly.dev/mcp` 입력.
+
+등록·재시작 후 규정을 자연어로 물으면 됩니다. 예:
+- "KOICA 승진 가점 규정 찾아줘"
+- "인사규정 제11조 본문 보여줘"
+- "이 보고서에 인용된 조문이 실재하는지 검증해줘"
+
+제공 도구 8종: `search_regulation`, `get_article`, `verify_citation`,
+`find_references`, `compliance_radar`, `list_attachments`, `get_attachment`,
+`list_sources`. 공개 서버라 토큰·헤더가 필요 없습니다.
+
+---
+
+## 🛠️ 이 저장소를 "개발·수정·기여"하려는 경우에만 clone
+
+```bash
+git clone https://github.com/amnotyoung/koica-reg-mcp.git
+cd koica-reg-mcp
+pip install -r requirements.txt
+python3 koica_search.py build      # data/extracted → data/index.json
+```
+
+- `koica_mcp_server.py` — 로컬 stdio 서버 (도구 11개 = 원격 8개 + `update`·`sync_from_alio`·`find_questions`)
+- `server_http.py` — 원격 HTTP(streamable-http) 서버 (읽기 8개)
+- `Dockerfile` + `fly.toml` — Fly.io 배포. **`main`에 머지되면 GitHub Actions가 자동 재배포**합니다.
+- 검색 엔진(`koica_search.py`)은 순수 표준 라이브러리(런타임 의존성은 `mcp` 하나).
+- 인덱스(`data/index.json`)는 gitignore되며, 이미지 빌드 시 `data/extracted/`에서 생성됩니다.
+
+---
+
+## 한 줄 요약
+
+**규정을 검색·활용하려는 목적 → 원격 URL 등록(clone 금지).
+코드를 고치려는 목적 → clone.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md — Claude Code / Claude 어시스턴트를 위한 안내
+
+**`koica-reg-mcp`는 이미 배포된 원격 MCP 서버입니다:** `https://koica-reg-mcp.fly.dev/mcp`
+
+## ✅ KOICA 규정 검색 도구로 쓰려는 경우 (대부분)
+
+⛔ `clone`·`build` 하지 마세요. 아래 한 줄로 등록하면 끝입니다:
+
+```bash
+claude mcp add --transport http koica-reg https://koica-reg-mcp.fly.dev/mcp
+```
+
+등록·재시작 후 KOICA 규정을 자연어로 물으면 `koica-reg` 도구(8종)가 자동 호출됩니다.
+예: "KOICA 승진 가점 규정 찾아줘", "인사규정 제11조 보여줘".
+공개 서버라 인증·토큰이 필요 없습니다.
+
+다른 클라이언트:
+- **Codex**: `codex mcp add koica-reg --url https://koica-reg-mcp.fly.dev/mcp`
+- **Claude Desktop / claude.ai**: 커넥터 설정 → "원격 MCP 서버 URL"에 위 주소.
+
+## 🛠️ 개발·수정하려는 경우에만 clone
+
+상세는 [AGENTS.md](AGENTS.md)와 [README](README.md) 참고.
+- 로컬 stdio: `koica_mcp_server.py`(도구 11개) / 원격 HTTP: `server_http.py`(읽기 8개)
+- 배포: `Dockerfile`+`fly.toml`(Fly.io). `main` 머지 시 자동 재배포.
+- 검색 엔진은 순수 표준 라이브러리(의존성 `mcp`뿐).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,31 @@
 # koica-reg-mcp
 
-**KOICA 현행 규정 149개를 11개 MCP 도구로.** 한국국제협력단 내부 규정을 조문 단위 검색 + 본문 직접 조회 + 인용 검증(제목 환각까지) + 상호참조 그래프 + **규정 정비 레이더**로, Claude Desktop·Cursor·Windsurf 등 MCP 호환 클라이언트에서 바로 사용. 규정 원본은 [ALIO(공공기관 경영정보 공개시스템)](https://www.alio.go.kr/item/itemOrganList.do?apbaId=C0146&reportFormRootNo=21110)에서 **자동 동기화**됩니다.
+**KOICA 현행 규정 149개를 MCP로 검색·조회.** 한국국제협력단 내부 규정을 조문 단위 검색 + 본문 직접 조회 + 인용 검증(제목 환각까지) + 상호참조 그래프 + **규정 정비 레이더**로, MCP 호환 클라이언트(Claude Desktop·claude.ai·Claude Code·Codex·Cursor 등)에서 사용. 규정 원본은 [ALIO(공공기관 경영정보 공개시스템)](https://www.alio.go.kr/item/itemOrganList.do?apbaId=C0146&reportFormRootNo=21110)에서 **자동 동기화**됩니다.
 
-[![MCP](https://img.shields.io/badge/MCP-1.0-blue)](https://modelcontextprotocol.io)
+[![MCP](https://img.shields.io/badge/MCP-streamable--http-blue)](https://modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> KOICA 직원이 일하다 "이거 인사규정 몇 조에 있더라?" 싶을 때, AI 어시스턴트에게 자연어로 물어보면 정확한 조문과 본문이 즉시 나옵니다.
+## 🚀 바로 쓰기 — 설치 불필요
 
-> ⚡ **설치 없이 바로 쓰기** — Claude 커넥터의 "원격 MCP 서버 URL"에 `https://koica-reg-mcp.fly.dev/mcp` 를 붙여넣기만 하면 됩니다. 자세히는 아래 [빠른 시작](#빠른-시작).
+**이건 이미 배포된 원격 MCP 서버입니다.** `clone`·`pip`·`build` 없이, 쓰는 클라이언트에 아래 URL 하나만 등록하면 끝입니다:
+
+```
+https://koica-reg-mcp.fly.dev/mcp
+```
+
+| 클라이언트 | 등록 방법 |
+|---|---|
+| **Claude Desktop / claude.ai (웹)** | 설정 → 커넥터 → *커스텀 커넥터 추가* → "원격 MCP 서버 URL"에 위 주소 입력 |
+| **Claude Code** | `claude mcp add --transport http koica-reg https://koica-reg-mcp.fly.dev/mcp` |
+| **Codex** | `codex mcp add koica-reg --url https://koica-reg-mcp.fly.dev/mcp` |
+
+등록·재시작 후 규정을 자연어로 물으면 됩니다 — 예: *"KOICA 승진 가점 규정 찾아줘"*, *"인사규정 제11조 보여줘"*. 공개 서버라 인증·토큰이 필요 없습니다.
+
+> 🛠️ **소스를 직접 수정할 게 아니라면 `git clone`은 필요 없습니다.** 저장소를 clone·build하는 건 개발·기여 목적일 때뿐입니다(→ 아래 [빠른 시작](#빠른-시작)의 로컬 설치, 그리고 [AGENTS.md](AGENTS.md) / [CLAUDE.md](CLAUDE.md)).
+
+---
+
+> KOICA 직원이 일하다 "이거 인사규정 몇 조에 있더라?" 싶을 때, AI 어시스턴트에게 자연어로 물어보면 정확한 조문과 본문이 즉시 나옵니다.
 
 ---
 


### PR DESCRIPTION
## 배경
`amnotyoung/koica-reg-mcp` 주소만 받은 Codex/Claude가 원격 서버로 붙지 않고 로컬 clone+build로 새는 사례. repo 주소 자체는 "원격 등록" 신호가 아니라, 에이전트가 코드로 다루려 하기 때문.

## 변경 — clone 대신 원격 URL 등록으로 유도하는 이정표
- **AGENTS.md** (신규) — Codex/범용 에이전트가 읽음. "사용=원격 등록 / 개발=clone" 구분, 클라이언트별 원라이너(Codex·Claude Code·Desktop).
- **CLAUDE.md** (신규) — Claude Code용. 동일 취지.
- **README 최상단** — 묻혀 있던 원격 안내를 "🚀 바로 쓰기 — 설치 불필요" 배너로 승격. 클라이언트별 등록법 표 + "소스 수정 아니면 clone 불필요" 문구.
- **.dockerignore** — AGENTS.md/CLAUDE.md는 런타임 이미지에 불필요하므로 제외.

## 한계
AI 행동은 확률적이라 100% 강제는 아니지만, 이정표가 전혀 없던 것과 비교해 clone 이탈이 크게 줄고 사람에게도 복붙 한 줄이 명확해짐.

🤖 Generated with [Claude Code](https://claude.com/claude-code)