### PR TITLE
feat: 도구 사용량 집계 (개인정보 미수집·영속화)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# 애플리케이션 코드 (server_http → koica_mcp_server → koica_search 의존)
-COPY koica_search.py koica_mcp_server.py server_http.py ./
+# 애플리케이션 코드 (server_http → koica_mcp_server → koica_search / usage_stats 의존)
+COPY koica_search.py koica_mcp_server.py server_http.py usage_stats.py ./
 
 # 데이터: 검색 인덱스 + 규정 본문. _cache(원본 HWP)/시험범위 PDF는 .dockerignore로 제외
 COPY data/ ./data/

--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,17 @@
 app = 'koica-reg-mcp'
 primary_region = 'nrt'
 
+# 사용량 통계 DB — 아래 [mounts] 볼륨(/data)에 두어 머신 정지·재배포에도 보존.
+# 이 env는 Fly 배포에만 존재하므로 로컬/도커 기본 실행에서는 집계가 꺼진다(no-op).
+[env]
+  KOICA_STATS_DB = '/data/usage.db'
+
+# 영속 볼륨. 최초 1회 생성 필요:
+#   fly volumes create koica_data --region nrt --size 1 --app koica-reg-mcp
+[mounts]
+  source = 'koica_data'
+  destination = '/data'
+
 [build]
 [http_service]
   internal_port = 8080

--- a/koica_mcp_server.py
+++ b/koica_mcp_server.py
@@ -28,6 +28,7 @@ from typing import Optional
 from mcp.server.fastmcp import FastMCP
 
 import koica_search as ks
+import usage_stats as _usage  # 도구 호출 횟수 집계(개인정보 미수집, best-effort)
 
 
 # 서버 소개(instructions) — MCP initialize 시 클라이언트(Claude)에 전달되어,
@@ -93,6 +94,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             article: source/article/article_title/snippet/citation/score
             attachment: source/kind/label/title/snippet/citation/score
         """
+        _usage.record("search_regulation")
         return ks.search(
             query,
             category=category,
@@ -121,6 +123,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             kind: "별표" 또는 "별지"로만 필터
             include_deleted: 본문에 <삭제 …> 메타가 있는 항목 포함 여부 (기본 False)
         """
+        _usage.record("list_attachments")
         return ks.list_attachments(source=source, category=category, kind=kind, include_deleted=include_deleted)
 
     @mcp.tool()
@@ -132,6 +135,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             label: 별표·별지 라벨. "[별표 1]", "별표 1", "1" 등 자유 형식.
                 공백·괄호 무시하고 정규화 매칭됨.
         """
+        _usage.record("get_attachment")
         return ks.get_attachment(source, label)
 
     @mcp.tool()
@@ -145,6 +149,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
         Returns:
             매칭 조문 배열. body 필드에 전체 본문 포함. 0건이면 빈 배열.
         """
+        _usage.record("get_article")
         return ks.get_article(source, article)
 
     @mcp.tool()
@@ -158,6 +163,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
         Args:
             text: 검증할 한국어 텍스트 (여러 인용이 섞여 있어도 됨)
         """
+        _usage.record("verify_citation")
         return ks.verify_citation(text)
 
     @mcp.tool()
@@ -178,6 +184,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             include_mermaid: True면 반환값에 "mermaid"(flowchart 코드) 포함.
                 claude.ai 등에서 인용망을 바로 시각화할 때 사용.
         """
+        _usage.record("find_references")
         return ks.find_references(source, article, limit=limit, include_mermaid=include_mermaid)
 
     @mcp.tool()
@@ -196,6 +203,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             [{source, type, revision, parent, parent_revision, status, note}, …]
             status: review_needed(모규정이 더 최근) / ok / unknown
         """
+        _usage.record("compliance_radar")
         return ks.compliance_radar(source=source)
 
     @mcp.tool()
@@ -209,6 +217,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             [{"source": "인사규정", "category": "규정", "revision": "2026.06.12 개정",
               "article_count": 73}, …]
         """
+        _usage.record("list_sources")
         arts = ks.load_index()
         by_src: dict[str, dict] = {}
         for a in arts:
@@ -224,6 +233,24 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
                 }
             by_src[key]["article_count"] += 1
         return sorted(by_src.values(), key=lambda x: (x["category"], x["source"]))
+
+    @mcp.tool()
+    def usage_stats() -> dict:
+        """이 서버의 도구별 누적 호출 횟수(사용량 통계).
+
+        개인정보는 담지 않습니다 — 도구명·호출 횟수·최초/최근 호출 시각(UTC)만
+        집계하며, 검색어·클라이언트 IP·신원 정보는 저장하지 않습니다. 이 도구
+        자신의 호출은 통계를 부풀리지 않도록 카운트에서 제외됩니다.
+
+        영속화가 켜져 있으면(서버에 KOICA_STATS_DB 설정) 머신 정지·재배포에도
+        수치가 보존됩니다. 꺼져 있으면 enabled=False로 빈 통계를 반환합니다.
+
+        Returns:
+            {"enabled": bool, "total": int,
+             "tools": [{"tool", "count", "first_seen", "last_seen"}, …]}
+        """
+        # 의도적으로 record() 호출 안 함 — 통계 조회가 통계를 오염시키지 않도록.
+        return _usage.snapshot()
 
     if include_questions:
         @mcp.tool()
@@ -242,6 +269,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             Returns:
                 문항 + 보기 + 정답 + 해설 + 근거 조문(자동 매핑된 본문 발췌).
             """
+            _usage.record("find_questions")
             return ks.find_questions(query=query, question_id=question_id, limit=limit)
 
     if not include_admin:
@@ -262,6 +290,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
         바뀐 경우(규정 추가/갱신)는 재시작 없이 즉시 사용 가능합니다. 반환값의
         restart_required와 restart_instruction을 사용자에게 그대로 전달하세요.
         """
+        _usage.record("update")
         return ks.self_update()
 
     @mcp.tool()
@@ -285,6 +314,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
         Returns:
             동기화 결과 요약(규정 수·조문 수, 실행 로그 tail).
         """
+        _usage.record("sync_from_alio")
         from pathlib import Path
 
         script = Path(ks.ROOT) / "alio_sync.py"

--- a/usage_stats.py
+++ b/usage_stats.py
@@ -1,0 +1,120 @@
+"""도구 호출 횟수 집계 — 개인정보 없이 도구명별 카운트만 영속 저장.
+
+무엇을 저장하나:
+  - 도구명(예: "search_regulation")과 누적 호출 횟수, 최초/최근 호출 시각(UTC).
+무엇을 저장하지 '않'나:
+  - 검색어·인자·응답 내용, 클라이언트 IP, 그 어떤 신원 정보도 저장하지 않는다.
+  따라서 개인정보(개인정보보호법상 IP 포함) 수집에 해당하지 않는다.
+
+영속화:
+  SQLite 파일(순수 표준 라이브러리). 경로는 환경변수 KOICA_STATS_DB로 지정한다.
+  Fly.io 에서는 볼륨(/data)에 두어 머신 정지·재배포에도 카운트가 보존된다.
+  KOICA_STATS_DB 가 없으면(예: 로컬 stdio 기본) 집계는 조용히 비활성(no-op)된다.
+
+안정성:
+  집계는 부가 기능이므로 항상 best-effort다. DB 쓰기/읽기가 실패해도 예외를
+  삼켜 도구 본연의 동작(규정 검색·조회)을 절대 방해하지 않는다.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import sqlite3
+import threading
+
+# 프로세스 내 쓰기 직렬화. 각 호출은 자기 스레드에서 커넥션을 새로 열고 닫으므로
+# sqlite3 기본(check_same_thread=True)과도 호환된다.
+_LOCK = threading.Lock()
+
+
+def _db_path() -> str | None:
+    """집계 DB 경로. 미설정이면 None → 집계 비활성."""
+    path = os.environ.get("KOICA_STATS_DB")
+    return path or None
+
+
+def _now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
+
+
+def _connect(path: str) -> sqlite3.Connection:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=5.0)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS tool_usage ("
+        " tool TEXT PRIMARY KEY,"
+        " count INTEGER NOT NULL DEFAULT 0,"
+        " first_seen TEXT,"
+        " last_seen TEXT)"
+    )
+    return conn
+
+
+def record(tool: str) -> None:
+    """도구 1회 호출을 기록(누적 +1). 실패는 조용히 무시한다."""
+    path = _db_path()
+    if not path:
+        return
+    try:
+        now = _now()
+        with _LOCK:
+            conn = _connect(path)
+            try:
+                conn.execute(
+                    "INSERT INTO tool_usage(tool, count, first_seen, last_seen)"
+                    " VALUES(?, 1, ?, ?)"
+                    " ON CONFLICT(tool) DO UPDATE SET"
+                    "  count = count + 1,"
+                    "  last_seen = excluded.last_seen",
+                    (tool, now, now),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+    except Exception:
+        # 집계는 부가 기능 — 어떤 실패도 도구 동작을 막지 않는다.
+        pass
+
+
+def snapshot() -> dict:
+    """현재 집계 스냅샷.
+
+    Returns:
+        {
+          "enabled": bool,           # KOICA_STATS_DB 설정 여부(영속화 활성)
+          "total": int,             # 전체 도구 누적 호출 합
+          "tools": [                # 호출 많은 순
+            {"tool", "count", "first_seen", "last_seen"}, …
+          ],
+        }
+        영속화 비활성 시 enabled=False, total=0, tools=[].
+    """
+    path = _db_path()
+    if not path:
+        return {"enabled": False, "total": 0, "tools": []}
+    try:
+        with _LOCK:
+            conn = _connect(path)
+            try:
+                rows = conn.execute(
+                    "SELECT tool, count, first_seen, last_seen"
+                    " FROM tool_usage ORDER BY count DESC, tool ASC"
+                ).fetchall()
+            finally:
+                conn.close()
+        tools = [
+            {"tool": r[0], "count": r[1], "first_seen": r[2], "last_seen": r[3]}
+            for r in rows
+        ]
+        return {
+            "enabled": True,
+            "total": sum(t["count"] for t in tools),
+            "tools": tools,
+        }
+    except Exception as exc:
+        # 읽기 실패도 도구 목록 조회 자체를 깨지 않도록 형태를 유지해 반환.
+        return {"enabled": True, "total": 0, "tools": [], "error": str(exc)}


### PR DESCRIPTION
## 무엇을

원격 MCP 서버(`koica-reg-mcp.fly.dev`)에 **도구별 사용량 집계**를 추가합니다. "어떤 도구가 몇 번 호출됐는지"를 `usage_stats` 도구로 조회할 수 있습니다.

## 개인정보 미수집

- **저장**: 도구명, 누적 호출 횟수, 최초/최근 호출 시각(UTC)
- **미저장**: 클라이언트 IP, 검색어·인자, 응답 내용, 신원 정보
- IP를 포함해 개인정보(개인정보보호법)에 해당하는 값은 일절 저장하지 않습니다.

## 변경

- **`usage_stats.py`**(신규): 순수 `sqlite3` 집계. DB 실패는 best-effort로 삼켜 규정 검색·조회 동작을 막지 않음.
- **`koica_mcp_server.py`**: 각 도구에 `record()` 훅을 docstring 다음 첫 실행문으로 배치(도구 설명 `__doc__` 보존) + 조회용 `usage_stats` 도구(읽기 전용 세트 → 원격 노출, 자기 호출은 카운트 제외).
- **`fly.toml`**: `/data` 영속 볼륨 마운트 + `KOICA_STATS_DB` env. env가 Fly 배포에만 있어 로컬 stdio/도커 기본 실행은 집계 OFF(no-op).
- **`Dockerfile`**: `usage_stats.py` 이미지 COPY 포함(누락 시 import 실패).

## 영속화 / 배포

- Fly 볼륨 `koica_data`(nrt, 1GB, 약 **$0.15/월**)는 **생성 완료**(`vol_rnzoj1xjxllxlgpr`). 머신 정지·재배포에도 카운트 보존.
- 이 PR을 **main에 머지하면 GitHub Actions가 자동배포**하고, 배포 후 라이브 서버에 `usage_stats` 도구가 생기며 집계가 시작됩니다.

## 검증 (로컬)

- **단위**: no-op 모드(env 없으면 미저장), 카운트/시각 집계, 재오픈 후 영속성
- **등록**: 원격(읽기 9종)에 `usage_stats` 노출, 관리·문항 도구 미노출, docstring/스키마 보존
- **실호출 E2E**: `call_tool` 경로로 `search_regulation`×2·`list_sources`×1 정확 집계, `usage_stats` 자기 제외 확인

**사용법(배포 후)**: 클라이언트에서 "koica-reg 사용량 통계 보여줘" → `usage_stats` 호출.

## ⚠️ 한 가지 참고

단일 머신 + 단일 볼륨 구성이라 집계는 정확합니다. 이후 머신을 2대 이상으로 수평 확장하면 각 머신이 자기 볼륨에 따로 세므로 카운트가 분산됩니다(현재는 해당 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
