### PR TITLE
feat: 사용량 통계에 검색어 언어 분포 추가 (ko/en/other)

### DIFF
--- a/koica_mcp_server.py
+++ b/koica_mcp_server.py
@@ -94,7 +94,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             article: source/article/article_title/snippet/citation/score
             attachment: source/kind/label/title/snippet/citation/score
         """
-        _usage.record("search_regulation")
+        _usage.record("search_regulation", text=query)
         return ks.search(
             query,
             category=category,
@@ -163,7 +163,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
         Args:
             text: 검증할 한국어 텍스트 (여러 인용이 섞여 있어도 됨)
         """
-        _usage.record("verify_citation")
+        _usage.record("verify_citation", text=text)
         return ks.verify_citation(text)
 
     @mcp.tool()
@@ -236,18 +236,23 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
 
     @mcp.tool()
     def usage_stats() -> dict:
-        """이 서버의 도구별 누적 호출 횟수(사용량 통계).
+        """이 서버의 도구별 누적 호출 횟수 + 검색어 언어 분포(사용량 통계).
 
-        개인정보는 담지 않습니다 — 도구명·호출 횟수·최초/최근 호출 시각(UTC)만
-        집계하며, 검색어·클라이언트 IP·신원 정보는 저장하지 않습니다. 이 도구
-        자신의 호출은 통계를 부풀리지 않도록 카운트에서 제외됩니다.
+        개인정보는 담지 않습니다 — 도구명·호출 횟수·시각(UTC)과, 자연어 검색어의
+        '언어 라벨'(ko/en/other)별 카운트만 집계합니다. 검색어 원문·클라이언트 IP·
+        신원 정보는 저장하지 않으며, 이 도구 자신의 호출은 카운트에서 제외됩니다.
+
+        by_language는 "국내만 쓰나 해외도 쓰나"의 거친 지표입니다. en이 잡히면
+        외국어 사용이 있다는 뜻이지만, LLM이 영어 질문을 한국어로 번역해 검색하는
+        경우가 많아 ko뿐이라고 외국인이 없다는 보장은 아닙니다(단방향 신호).
 
         영속화가 켜져 있으면(서버에 KOICA_STATS_DB 설정) 머신 정지·재배포에도
         수치가 보존됩니다. 꺼져 있으면 enabled=False로 빈 통계를 반환합니다.
 
         Returns:
             {"enabled": bool, "total": int,
-             "tools": [{"tool", "count", "first_seen", "last_seen"}, …]}
+             "tools": [{"tool", "count", "first_seen", "last_seen"}, …],
+             "by_language": [{"lang", "count", "first_seen", "last_seen"}, …]}
         """
         # 의도적으로 record() 호출 안 함 — 통계 조회가 통계를 오염시키지 않도록.
         return _usage.snapshot()
@@ -269,7 +274,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             Returns:
                 문항 + 보기 + 정답 + 해설 + 근거 조문(자동 매핑된 본문 발췌).
             """
-            _usage.record("find_questions")
+            _usage.record("find_questions", text=query)
             return ks.find_questions(query=query, question_id=question_id, limit=limit)
 
     if not include_admin:

--- a/usage_stats.py
+++ b/usage_stats.py
@@ -1,10 +1,19 @@
-"""도구 호출 횟수 집계 — 개인정보 없이 도구명별 카운트만 영속 저장.
+"""도구 호출 횟수 집계 — 개인정보 없이 카운트만 영속 저장.
 
 무엇을 저장하나:
   - 도구명(예: "search_regulation")과 누적 호출 횟수, 최초/최근 호출 시각(UTC).
+  - 자연어 검색어의 '언어 라벨'(ko/en/other)별 카운트. 검색어 원문이 아니라
+    어떤 문자체계인지(한글 포함→ko / 라틴문자 포함→en / 그 외→other)만 판별해
+    라벨만 센다. "국내만 쓰나 해외도 쓰나"를 가늠하기 위한 거친 신호다.
 무엇을 저장하지 '않'나:
-  - 검색어·인자·응답 내용, 클라이언트 IP, 그 어떤 신원 정보도 저장하지 않는다.
-  따라서 개인정보(개인정보보호법상 IP 포함) 수집에 해당하지 않는다.
+  - 검색어·인자 원문, 응답 내용, 클라이언트 IP, 그 어떤 신원 정보도 저장하지 않는다.
+  언어 라벨은 개인을 식별하지 않으므로, 전체적으로 개인정보(개인정보보호법상 IP
+  포함) 수집에 해당하지 않는다.
+
+주의(언어 신호의 한계):
+  코퍼스가 한국어라 LLM이 영어 사용자의 질문도 한국어 검색어로 번역해 보내는
+  경우가 많다. 따라서 'en'이 잡히면 외국어 사용이 확실히 있다는 뜻이지만,
+  'ko'뿐이라고 해서 외국인이 없다는 보장은 안 된다(단방향 신호).
 
 영속화:
   SQLite 파일(순수 표준 라이브러리). 경로는 환경변수 KOICA_STATS_DB로 지정한다.
@@ -38,6 +47,30 @@ def _now() -> str:
     return datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
 
 
+def detect_lang(text: str | None) -> str | None:
+    """검색어의 언어 라벨을 반환한다 — 개인정보 아님(원문 미저장, 라벨만).
+
+    - 한글(음절·자모)이 하나라도 있으면 "ko" (예: "승진 가점", "KOICA 승진")
+    - 아니고 라틴문자가 있으면 "en" (영어 등 라틴 문자체계, 예: "promotion bonus")
+    - 그 외(숫자·기호·다른 문자체계만)면 "other"
+    - 비었거나 공백뿐이면 None(집계 제외)
+
+    한글 우선 판정이라 "KOICA 승진"처럼 한글+영문 혼용은 ko로 잡힌다(한국인이
+    영문 약어를 섞어 쓴 경우를 올바르게 분류).
+    """
+    if not text or not text.strip():
+        return None
+    for ch in text:
+        o = ord(ch)
+        if 0xAC00 <= o <= 0xD7A3 or 0x1100 <= o <= 0x11FF or 0x3130 <= o <= 0x318F:
+            return "ko"
+    for ch in text:
+        o = ord(ch)
+        if 0x41 <= o <= 0x5A or 0x61 <= o <= 0x7A:
+            return "en"
+    return "other"
+
+
 def _connect(path: str) -> sqlite3.Connection:
     parent = os.path.dirname(path)
     if parent:
@@ -51,27 +84,45 @@ def _connect(path: str) -> sqlite3.Connection:
         " first_seen TEXT,"
         " last_seen TEXT)"
     )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS lang_usage ("
+        " lang TEXT PRIMARY KEY,"
+        " count INTEGER NOT NULL DEFAULT 0,"
+        " first_seen TEXT,"
+        " last_seen TEXT)"
+    )
     return conn
 
 
-def record(tool: str) -> None:
-    """도구 1회 호출을 기록(누적 +1). 실패는 조용히 무시한다."""
+def _bump(conn: sqlite3.Connection, table: str, key_col: str, key: str, now: str) -> None:
+    conn.execute(
+        f"INSERT INTO {table}({key_col}, count, first_seen, last_seen)"
+        " VALUES(?, 1, ?, ?)"
+        f" ON CONFLICT({key_col}) DO UPDATE SET"
+        "  count = count + 1,"
+        "  last_seen = excluded.last_seen",
+        (key, now, now),
+    )
+
+
+def record(tool: str, text: str | None = None) -> None:
+    """도구 1회 호출을 기록(누적 +1).
+
+    text가 주어지면(자연어 검색어) 그 언어 라벨(ko/en/other)도 함께 집계한다.
+    검색어 원문은 저장하지 않고 라벨만 센다. 실패는 조용히 무시한다(best-effort).
+    """
     path = _db_path()
     if not path:
         return
     try:
         now = _now()
+        lang = detect_lang(text)
         with _LOCK:
             conn = _connect(path)
             try:
-                conn.execute(
-                    "INSERT INTO tool_usage(tool, count, first_seen, last_seen)"
-                    " VALUES(?, 1, ?, ?)"
-                    " ON CONFLICT(tool) DO UPDATE SET"
-                    "  count = count + 1,"
-                    "  last_seen = excluded.last_seen",
-                    (tool, now, now),
-                )
+                _bump(conn, "tool_usage", "tool", tool, now)
+                if lang:
+                    _bump(conn, "lang_usage", "lang", lang, now)
                 conn.commit()
             finally:
                 conn.close()
@@ -90,31 +141,43 @@ def snapshot() -> dict:
           "tools": [                # 호출 많은 순
             {"tool", "count", "first_seen", "last_seen"}, …
           ],
+          "by_language": [          # 자연어 검색어 언어 라벨별 집계(많은 순)
+            {"lang", "count", "first_seen", "last_seen"}, …
+          ],
         }
-        영속화 비활성 시 enabled=False, total=0, tools=[].
+        영속화 비활성 시 enabled=False, 나머지는 빈 값.
     """
     path = _db_path()
     if not path:
-        return {"enabled": False, "total": 0, "tools": []}
+        return {"enabled": False, "total": 0, "tools": [], "by_language": []}
     try:
         with _LOCK:
             conn = _connect(path)
             try:
-                rows = conn.execute(
+                tool_rows = conn.execute(
                     "SELECT tool, count, first_seen, last_seen"
                     " FROM tool_usage ORDER BY count DESC, tool ASC"
+                ).fetchall()
+                lang_rows = conn.execute(
+                    "SELECT lang, count, first_seen, last_seen"
+                    " FROM lang_usage ORDER BY count DESC, lang ASC"
                 ).fetchall()
             finally:
                 conn.close()
         tools = [
             {"tool": r[0], "count": r[1], "first_seen": r[2], "last_seen": r[3]}
-            for r in rows
+            for r in tool_rows
+        ]
+        by_language = [
+            {"lang": r[0], "count": r[1], "first_seen": r[2], "last_seen": r[3]}
+            for r in lang_rows
         ]
         return {
             "enabled": True,
             "total": sum(t["count"] for t in tools),
             "tools": tools,
+            "by_language": by_language,
         }
     except Exception as exc:
         # 읽기 실패도 도구 목록 조회 자체를 깨지 않도록 형태를 유지해 반환.
-        return {"enabled": True, "total": 0, "tools": [], "error": str(exc)}
+        return {"enabled": True, "total": 0, "tools": [], "by_language": [], "error": str(exc)}


### PR DESCRIPTION
## 무엇을

`usage_stats`에 **검색어 언어 분포**(`by_language`)를 추가합니다. "이 서버를 국내에서만 쓰나, 해외에서도 쓰나"를 가늠하기 위한 거친 신호입니다.

## 왜 IP(geo) 대신 언어인가

- **IP는 신뢰 불가**: claude.ai(웹)로 접속하면 서버엔 Anthropic 백엔드(미국 데이터센터) IP가 찍혀, 한국 사용자가 해외로 오인됩니다. 로컬 클라이언트만 실제 국가가 드러남.
- **언어는 그 함정이 없음**: 검색어의 언어는 접속 경로와 무관합니다.
- **개인정보도 안 건드림**: IP는 개인정보지만, 검색어의 *언어 라벨*은 개인을 식별하지 않습니다. 기존 "개인정보 0" 원칙 유지.

## 무엇을 저장/미저장

- **저장**: 언어 라벨(`ko`/`en`/`other`)별 카운트 + 최초/최근 시각.
- **미저장**: 검색어 원문, IP, 신원. 어떤 문자체계인지만 판별(유니코드 범위)하고 라벨만 셈.

## ⚠️ 한계 — 단방향 신호

코퍼스가 한국어라, LLM이 영어 질문을 **한국어 검색어로 번역**해 보내는 경우가 많습니다.

| 관측 | 해석 |
|---|---|
| `en`(비한국어)이 잡힘 | ✅ 외국어 사용 **확실히 있음** |
| `ko`만 잡힘 | ⚠️ **불확실** (번역됐을 수 있음) |

즉 "외국인 사용 여부(YES)"는 잡지만 "정확한 비율/NO"는 못 잽니다.

## 변경

- **`usage_stats.py`**: `detect_lang()`(라이브러리 불필요), `lang_usage` 테이블, `snapshot().by_language`. `record(tool, text=)`로 확장. 기존 `tool_usage`만 있는 DB도 `CREATE TABLE IF NOT EXISTS`로 **무손실 마이그레이션**.
- **`koica_mcp_server.py`**: 자연어 입력이 있는 `search_regulation`·`verify_citation`·`find_questions`만 `text`를 넘겨 언어 집계(규정명 인자 `source`/`category`는 제외 → 신호 오염 방지).

## 검증 (로컬)

- `detect_lang`: 한글/라틴/기타/빈값 분류, "KOICA 승진"→ko(한글 우선)
- 이중 집계: 도구+언어, text 없는 도구는 언어 미집계
- **하위호환**: 기존 카운트 보존 + `lang_usage` 신규 생성
- 실호출 E2E: `call_tool`로 영어 쿼리→en·한국어→ko, 도구 스키마 불변

## 배포 후 참고

`by_language`는 배포 시점부터 채워집니다. 기존 18건(언어 미수집 시절)은 라벨이 없어 `by_language`엔 안 잡히고, 이후 실사용부터 쌓입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
