### PR TITLE
feat: 사용량 통계 조회를 소유자 전용으로 잠금

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # 애플리케이션 코드 (server_http → koica_mcp_server → koica_search / usage_stats 의존)
-COPY koica_search.py koica_mcp_server.py server_http.py usage_stats.py ./
+# stats_cli.py: 소유자 전용 사용량 조회(공개 MCP엔 usage_stats 미노출, fly ssh로만 읽음)
+COPY koica_search.py koica_mcp_server.py server_http.py usage_stats.py stats_cli.py ./
 
 # 데이터: 검색 인덱스 + 규정 본문. _cache(원본 HWP)/시험범위 PDF는 .dockerignore로 제외
 COPY data/ ./data/

--- a/koica_mcp_server.py
+++ b/koica_mcp_server.py
@@ -234,28 +234,9 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             by_src[key]["article_count"] += 1
         return sorted(by_src.values(), key=lambda x: (x["category"], x["source"]))
 
-    @mcp.tool()
-    def usage_stats() -> dict:
-        """이 서버의 도구별 누적 호출 횟수 + 검색어 언어 분포(사용량 통계).
-
-        개인정보는 담지 않습니다 — 도구명·호출 횟수·시각(UTC)과, 자연어 검색어의
-        '언어 라벨'(ko/en/other)별 카운트만 집계합니다. 검색어 원문·클라이언트 IP·
-        신원 정보는 저장하지 않으며, 이 도구 자신의 호출은 카운트에서 제외됩니다.
-
-        by_language는 "국내만 쓰나 해외도 쓰나"의 거친 지표입니다. en이 잡히면
-        외국어 사용이 있다는 뜻이지만, LLM이 영어 질문을 한국어로 번역해 검색하는
-        경우가 많아 ko뿐이라고 외국인이 없다는 보장은 아닙니다(단방향 신호).
-
-        영속화가 켜져 있으면(서버에 KOICA_STATS_DB 설정) 머신 정지·재배포에도
-        수치가 보존됩니다. 꺼져 있으면 enabled=False로 빈 통계를 반환합니다.
-
-        Returns:
-            {"enabled": bool, "total": int,
-             "tools": [{"tool", "count", "first_seen", "last_seen"}, …],
-             "by_language": [{"lang", "count", "first_seen", "last_seen"}, …]}
-        """
-        # 의도적으로 record() 호출 안 함 — 통계 조회가 통계를 오염시키지 않도록.
-        return _usage.snapshot()
+    # 주의: 사용량 조회 도구(usage_stats)는 공개 MCP 표면에 노출하지 않는다.
+    # 집계(record)는 계속 하되, 조회는 소유자만 가능하도록 Fly 머신 안에서
+    # stats_cli.py 를 fly ssh 로 실행해서만 읽는다(사용법은 stats_cli.py 참고).
 
     if include_questions:
         @mcp.tool()

--- a/stats_cli.py
+++ b/stats_cli.py
@@ -1,0 +1,25 @@
+"""소유자 전용 사용량 통계 조회 CLI.
+
+공개 MCP 표면에서 usage_stats 도구를 제거했으므로(누구나 조회 방지), 프로덕션
+통계는 이 스크립트를 Fly 머신 안에서 실행해 owner 인증(flyctl)으로만 조회한다:
+
+    fly ssh console --app koica-reg-mcp -C "python3 /app/stats_cli.py"
+
+- 집계(record) 자체는 공개 서버에서 계속 이뤄지고, '읽기'만 소유자로 제한된다.
+- KOICA_STATS_DB 미설정 시 Fly 볼륨 경로(/data/usage.db)를 기본값으로 쓴다.
+  로컬에서 다른 DB를 보려면 KOICA_STATS_DB 를 지정한 뒤 실행하면 된다.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+# fly ssh 세션은 앱 프로세스의 [env]를 물려받지 않을 수 있으므로 기본 경로를 보장.
+os.environ.setdefault("KOICA_STATS_DB", "/data/usage.db")
+
+import usage_stats
+
+
+if __name__ == "__main__":
+    print(json.dumps(usage_stats.snapshot(), ensure_ascii=False, indent=2))


### PR DESCRIPTION
## 무엇을

사용량 통계 **조회를 소유자 전용으로 잠급니다.** 공개 MCP 표면에서 `usage_stats` 도구를 제거하고, 통계는 owner 인증(flyctl)이 필요한 `fly ssh` 경로로만 읽습니다.

## 왜

`koica-reg-mcp.fly.dev`는 **무인증 공개 서버**라, `usage_stats`가 도구로 노출돼 있으면 커넥터를 등록한 **누구나** 집계 수치를 볼 수 있었습니다. 수치 자체엔 개인정보가 없지만, "사용량 규모조차 남에게 안 보이게" 하려면 조회를 제한해야 합니다.

## 어떻게

- **집계(record)는 그대로 유지** → 데이터는 공개 서버에서 계속 쌓입니다.
- **조회만 소유자로 제한** → 공개/로컬 MCP 양쪽에서 `usage_stats` 도구 제거.
- **읽기 경로**: Fly 볼륨의 `usage.db`를 머신 안에서 읽는 `stats_cli.py`. `fly ssh`는 owner 인증이 필요하므로 사실상 소유자만 접근 가능:

  ```bash
  fly ssh console --app koica-reg-mcp -C "python3 /app/stats_cli.py"
  ```

## 변경

- **`koica_mcp_server.py`**: `usage_stats` 도구 등록 제거(공개·로컬 모두). `record` 훅·나머지 도구는 유지.
- **`stats_cli.py`**(신규): 소유자 전용 조회 CLI. `KOICA_STATS_DB` 미설정 시 `/data/usage.db` 기본값.
- **`Dockerfile`**: `stats_cli.py` 이미지 포함.

## 검증 (로컬)

- 공개(server_http)·로컬(koica_mcp_server) MCP 도구 목록에서 `usage_stats` 사라짐, 나머지 도구·집계 훅 유지
- `search_regulation` 실호출 → DB 집계 정상(by_language 포함)
- `stats_cli.py` 실행 → 스냅샷 JSON 정상 출력

## 트레이드오프

이제 챗 클라이언트에서 "사용량 통계 보여줘"로 바로 못 부릅니다. 대신 위 `fly ssh` 명령으로(또는 flyctl 있는 Claude Code를 통해) 조회합니다. 집계 데이터(현재 28건+)는 그대로 보존됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
