### PR TITLE
feat: 사용량 통계 일자별 버킷 추가 (이번 주 조회)

### DIFF
--- a/stats_cli.py
+++ b/stats_cli.py
@@ -1,9 +1,12 @@
 """소유자 전용 사용량 통계 조회 CLI.
 
 공개 MCP 표면에서 usage_stats 도구를 제거했으므로(누구나 조회 방지), 프로덕션
-통계는 이 스크립트를 Fly 머신 안에서 실행해 owner 인증(flyctl)으로만 조회한다:
+통계는 이 스크립트를 Fly 머신 안에서 실행해 owner 인증(flyctl)으로만 조회한다.
 
-    fly ssh console --app koica-reg-mcp -C "python3 /app/stats_cli.py"
+사용법(Fly 머신 안, fly ssh 로만 접근):
+    fly ssh console --app koica-reg-mcp -C "python3 /app/stats_cli.py"              # 전체(누적+일자별)
+    fly ssh console --app koica-reg-mcp -C "python3 /app/stats_cli.py week"         # 이번 주(KST, 월~일)
+    fly ssh console --app koica-reg-mcp -C "python3 /app/stats_cli.py backfill-legacy"  # 1회성 과거분 일자 반영
 
 - 집계(record) 자체는 공개 서버에서 계속 이뤄지고, '읽기'만 소유자로 제한된다.
 - KOICA_STATS_DB 미설정 시 Fly 볼륨 경로(/data/usage.db)를 기본값으로 쓴다.
@@ -12,14 +15,103 @@
 
 from __future__ import annotations
 
+import datetime
 import json
 import os
+import sys
 
 # fly ssh 세션은 앱 프로세스의 [env]를 물려받지 않을 수 있으므로 기본 경로를 보장.
 os.environ.setdefault("KOICA_STATS_DB", "/data/usage.db")
 
 import usage_stats
 
+_KST = datetime.timezone(datetime.timedelta(hours=9))
+
+
+def _this_week_range() -> tuple[str, str]:
+    """이번 주(KST) 월요일~일요일 날짜 범위 'YYYY-MM-DD'."""
+    today = datetime.datetime.now(_KST).date()
+    monday = today - datetime.timedelta(days=today.weekday())
+    sunday = monday + datetime.timedelta(days=6)
+    return monday.isoformat(), sunday.isoformat()
+
+
+def _sorted_desc(counts: dict) -> dict:
+    return dict(sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def _week_view(snap: dict) -> dict:
+    start, end = _this_week_range()
+    days = [d for d in snap.get("daily", []) if start <= d["day"] <= end]
+    tools: dict = {}
+    langs: dict = {}
+    total = 0
+    for d in days:
+        total += d["total"]
+        for t, c in d["tools"].items():
+            tools[t] = tools.get(t, 0) + c
+        for lang, c in d["by_language"].items():
+            langs[lang] = langs.get(lang, 0) + c
+    return {
+        "mode": "week",
+        "tz": "KST",
+        "week_start": start,
+        "week_end": end,
+        "total": total,
+        "tools": _sorted_desc(tools),
+        "by_language": _sorted_desc(langs),
+        "days": days,
+    }
+
+
+def _backfill_legacy() -> dict:
+    """일자 버킷 도입 이전의 누적분을 일자 버킷에 1회 반영.
+
+    각 도구/언어의 누적 카운트를 그 last_seen 날짜(KST)에 귀속시킨다. INSERT OR
+    IGNORE 라 같은 (날짜, 키)가 이미 있으면 건드리지 않으므로 여러 번 실행해도
+    안전하다. 이후 트래픽은 record()가 실시간으로 일자 버킷에 쌓는다.
+
+    한계: 한 도구의 과거 호출이 여러 날에 걸쳐 있었다면 전부 last_seen 날짜 하루로
+    몰아 귀속된다(근사). 도입 전환 시점의 1회성 시드 용도다.
+    """
+    path = usage_stats._db_path()
+    if not path:
+        return {"ok": False, "reason": "KOICA_STATS_DB 미설정"}
+    conn = usage_stats._connect(path)  # 테이블 보장
+    try:
+        c1 = conn.execute(
+            "INSERT OR IGNORE INTO daily_tool(day, tool, count)"
+            " SELECT substr(datetime(last_seen, '+9 hours'), 1, 10), tool, count"
+            " FROM tool_usage"
+        )
+        inserted_tool = c1.rowcount
+        c2 = conn.execute(
+            "INSERT OR IGNORE INTO daily_lang(day, lang, count)"
+            " SELECT substr(datetime(last_seen, '+9 hours'), 1, 10), lang, count"
+            " FROM lang_usage"
+        )
+        inserted_lang = c2.rowcount
+        conn.commit()
+    finally:
+        conn.close()
+    return {
+        "ok": True,
+        "inserted_daily_tool_rows": inserted_tool,
+        "inserted_daily_lang_rows": inserted_lang,
+    }
+
+
+def main(argv: list[str]) -> None:
+    mode = argv[1] if len(argv) > 1 else ""
+    if mode == "backfill-legacy":
+        result = _backfill_legacy()
+        result["result_week"] = _week_view(usage_stats.snapshot())
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return
+    snap = usage_stats.snapshot()
+    out = _week_view(snap) if mode == "week" else snap
+    print(json.dumps(out, ensure_ascii=False, indent=2))
+
 
 if __name__ == "__main__":
-    print(json.dumps(usage_stats.snapshot(), ensure_ascii=False, indent=2))
+    main(sys.argv)

--- a/usage_stats.py
+++ b/usage_stats.py
@@ -2,18 +2,25 @@
 
 무엇을 저장하나:
   - 도구명(예: "search_regulation")과 누적 호출 횟수, 최초/최근 호출 시각(UTC).
-  - 자연어 검색어의 '언어 라벨'(ko/en/other)별 카운트. 검색어 원문이 아니라
+  - 자연어 검색어의 '언어 라벨'(ko/en/other)별 누적 카운트. 검색어 원문이 아니라
     어떤 문자체계인지(한글 포함→ko / 라틴문자 포함→en / 그 외→other)만 판별해
-    라벨만 센다. "국내만 쓰나 해외도 쓰나"를 가늠하기 위한 거친 신호다.
+    라벨만 센다.
+  - 위 둘의 '일자별' 버킷(KST 날짜 기준): 날짜+도구+횟수, 날짜+언어+횟수.
+    "이번 주/일자별"처럼 기간을 잘라 보기 위한 것.
 무엇을 저장하지 '않'나:
   - 검색어·인자 원문, 응답 내용, 클라이언트 IP, 그 어떤 신원 정보도 저장하지 않는다.
-  언어 라벨은 개인을 식별하지 않으므로, 전체적으로 개인정보(개인정보보호법상 IP
-  포함) 수집에 해당하지 않는다.
+  언어 라벨·날짜·횟수는 개인을 식별하지 않으므로, 전체적으로 개인정보(개인정보보호법상
+  IP 포함) 수집에 해당하지 않는다.
 
-주의(언어 신호의 한계):
-  코퍼스가 한국어라 LLM이 영어 사용자의 질문도 한국어 검색어로 번역해 보내는
-  경우가 많다. 따라서 'en'이 잡히면 외국어 사용이 확실히 있다는 뜻이지만,
-  'ko'뿐이라고 해서 외국인이 없다는 보장은 안 된다(단방향 신호).
+일자 기준(KST):
+  일자 버킷의 '날짜'는 한국 시간(UTC+9, DST 없음) 기준이다. 최초/최근 시각
+  타임스탬프는 UTC로 저장하지만, "며칠에 몇 건"의 날짜 경계는 한국 사용자의
+  하루(자정~자정 KST)와 맞춘다.
+
+언어 신호의 한계:
+  코퍼스가 한국어라 LLM이 영어 질문을 한국어 검색어로 번역해 보내는 경우가 많다.
+  'en'이 잡히면 외국어 사용이 확실히 있다는 뜻이지만, 'ko'뿐이라고 외국인이
+  없다는 보장은 안 된다(단방향 신호).
 
 영속화:
   SQLite 파일(순수 표준 라이브러리). 경로는 환경변수 KOICA_STATS_DB로 지정한다.
@@ -36,6 +43,9 @@ import threading
 # sqlite3 기본(check_same_thread=True)과도 호환된다.
 _LOCK = threading.Lock()
 
+# 한국 표준시(UTC+9, 서머타임 없음) — 일자 버킷의 날짜 경계 기준.
+_KST = datetime.timezone(datetime.timedelta(hours=9))
+
 
 def _db_path() -> str | None:
     """집계 DB 경로. 미설정이면 None → 집계 비활성."""
@@ -45,6 +55,11 @@ def _db_path() -> str | None:
 
 def _now() -> str:
     return datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
+
+
+def _kst_day() -> str:
+    """오늘 날짜(KST) 'YYYY-MM-DD'. 일자 버킷 키."""
+    return datetime.datetime.now(_KST).date().isoformat()
 
 
 def detect_lang(text: str | None) -> str | None:
@@ -77,6 +92,7 @@ def _connect(path: str) -> sqlite3.Connection:
         os.makedirs(parent, exist_ok=True)
     conn = sqlite3.connect(path, timeout=5.0)
     conn.execute("PRAGMA journal_mode=WAL")
+    # 누적(전체 기간)
     conn.execute(
         "CREATE TABLE IF NOT EXISTS tool_usage ("
         " tool TEXT PRIMARY KEY,"
@@ -90,6 +106,19 @@ def _connect(path: str) -> sqlite3.Connection:
         " count INTEGER NOT NULL DEFAULT 0,"
         " first_seen TEXT,"
         " last_seen TEXT)"
+    )
+    # 일자별 버킷(KST 날짜)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS daily_tool ("
+        " day TEXT, tool TEXT,"
+        " count INTEGER NOT NULL DEFAULT 0,"
+        " PRIMARY KEY (day, tool))"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS daily_lang ("
+        " day TEXT, lang TEXT,"
+        " count INTEGER NOT NULL DEFAULT 0,"
+        " PRIMARY KEY (day, lang))"
     )
     return conn
 
@@ -105,10 +134,18 @@ def _bump(conn: sqlite3.Connection, table: str, key_col: str, key: str, now: str
     )
 
 
-def record(tool: str, text: str | None = None) -> None:
-    """도구 1회 호출을 기록(누적 +1).
+def _bump_daily(conn: sqlite3.Connection, table: str, key_col: str, day: str, key: str) -> None:
+    conn.execute(
+        f"INSERT INTO {table}(day, {key_col}, count) VALUES(?, ?, 1)"
+        f" ON CONFLICT(day, {key_col}) DO UPDATE SET count = count + 1",
+        (day, key),
+    )
 
-    text가 주어지면(자연어 검색어) 그 언어 라벨(ko/en/other)도 함께 집계한다.
+
+def record(tool: str, text: str | None = None) -> None:
+    """도구 1회 호출을 기록(누적 +1, 오늘(KST) 일자 버킷 +1).
+
+    text가 주어지면(자연어 검색어) 그 언어 라벨(ko/en/other)도 누적·일자로 집계.
     검색어 원문은 저장하지 않고 라벨만 센다. 실패는 조용히 무시한다(best-effort).
     """
     path = _db_path()
@@ -116,19 +153,43 @@ def record(tool: str, text: str | None = None) -> None:
         return
     try:
         now = _now()
+        day = _kst_day()
         lang = detect_lang(text)
         with _LOCK:
             conn = _connect(path)
             try:
                 _bump(conn, "tool_usage", "tool", tool, now)
+                _bump_daily(conn, "daily_tool", "tool", day, tool)
                 if lang:
                     _bump(conn, "lang_usage", "lang", lang, now)
+                    _bump_daily(conn, "daily_lang", "lang", day, lang)
                 conn.commit()
             finally:
                 conn.close()
     except Exception:
         # 집계는 부가 기능 — 어떤 실패도 도구 동작을 막지 않는다.
         pass
+
+
+def _daily_breakdown(conn: sqlite3.Connection) -> list[dict]:
+    """일자별 버킷을 {day, total, tools:{}, by_language:{}} 리스트(최근 날짜 순)로."""
+    days: dict[str, dict] = {}
+
+    def _slot(day: str) -> dict:
+        return days.setdefault(day, {"day": day, "total": 0, "tools": {}, "by_language": {}})
+
+    for day, tool, count in conn.execute(
+        "SELECT day, tool, count FROM daily_tool"
+    ).fetchall():
+        slot = _slot(day)
+        slot["tools"][tool] = count
+        slot["total"] += count            # total 은 도구 호출 합계
+    for day, lang, count in conn.execute(
+        "SELECT day, lang, count FROM daily_lang"
+    ).fetchall():
+        _slot(day)["by_language"][lang] = count   # 언어는 하위 분해라 total 에 더하지 않음
+
+    return sorted(days.values(), key=lambda d: d["day"], reverse=True)
 
 
 def snapshot() -> dict:
@@ -138,18 +199,17 @@ def snapshot() -> dict:
         {
           "enabled": bool,           # KOICA_STATS_DB 설정 여부(영속화 활성)
           "total": int,             # 전체 도구 누적 호출 합
-          "tools": [                # 호출 많은 순
-            {"tool", "count", "first_seen", "last_seen"}, …
-          ],
-          "by_language": [          # 자연어 검색어 언어 라벨별 집계(많은 순)
-            {"lang", "count", "first_seen", "last_seen"}, …
+          "tools": [{"tool","count","first_seen","last_seen"}, …],       # 많은 순
+          "by_language": [{"lang","count","first_seen","last_seen"}, …], # 많은 순
+          "daily": [                # 일자별(KST) 버킷, 최근 날짜 순
+            {"day","total","tools":{tool:count},"by_language":{lang:count}}, …
           ],
         }
         영속화 비활성 시 enabled=False, 나머지는 빈 값.
     """
     path = _db_path()
     if not path:
-        return {"enabled": False, "total": 0, "tools": [], "by_language": []}
+        return {"enabled": False, "total": 0, "tools": [], "by_language": [], "daily": []}
     try:
         with _LOCK:
             conn = _connect(path)
@@ -162,6 +222,7 @@ def snapshot() -> dict:
                     "SELECT lang, count, first_seen, last_seen"
                     " FROM lang_usage ORDER BY count DESC, lang ASC"
                 ).fetchall()
+                daily = _daily_breakdown(conn)
             finally:
                 conn.close()
         tools = [
@@ -177,7 +238,8 @@ def snapshot() -> dict:
             "total": sum(t["count"] for t in tools),
             "tools": tools,
             "by_language": by_language,
+            "daily": daily,
         }
     except Exception as exc:
-        # 읽기 실패도 도구 목록 조회 자체를 깨지 않도록 형태를 유지해 반환.
-        return {"enabled": True, "total": 0, "tools": [], "by_language": [], "error": str(exc)}
+        # 읽기 실패도 조회 자체를 깨지 않도록 형태를 유지해 반환.
+        return {"enabled": True, "total": 0, "tools": [], "by_language": [], "daily": [], "error": str(exc)}


### PR DESCRIPTION
## 무엇을

사용량 통계에 **일자별 버킷**을 추가해 "이번 주/일자별"로 잘라 볼 수 있게 합니다. 누적 카운터만으로는 기간 슬라이싱이 안 됐던 걸 해결합니다.

## 개인정보 미수집 유지

여전히 IP·검색어 원문·신원 없이, **"날짜(KST)+도구+횟수"**와 **"날짜+언어+횟수"**만 쌓습니다. 날짜·횟수·언어 라벨은 개인을 식별하지 않습니다.

## 변경

- **`usage_stats.py`**: `daily_tool`·`daily_lang` 테이블(KST 날짜 기준) 추가, `record()`가 누적과 함께 오늘(KST) 일자 버킷도 +1. `snapshot()`에 `daily`(최근 날짜 순) 추가. 누적 테이블·기존 스키마 그대로 → 무손실.
- **`stats_cli.py`**:
  - `week` — 이번 주(KST, 월~일) 합계 뷰
  - `backfill-legacy` — 일자 버킷 도입 이전 누적분을 `last_seen` 날짜(KST)에 1회 귀속. `INSERT OR IGNORE`라 여러 번 실행해도 안전(idempotent).

## 날짜 기준

일자 버킷의 '날짜'는 **한국시간(UTC+9)** 기준입니다(타임스탬프는 UTC 저장). 한국 사용자의 하루/한 주 경계와 맞추기 위함.

## 검증 (로컬)

- 일자 버킷 집계, 다일자 정렬, 이번 주 필터(2026-07-06~12)
- `stats_cli` `week`/기본/`backfill-legacy` 모드
- **백필**: 프로덕션 형태(누적만, `last_seen` 07-10)에서 실행 → 07-10에 28건 정확 귀속, 이번 주 28 반영, 재실행 시 0건 삽입(중복 없음)
- 하위호환: `daily` 테이블 없는 옛 DB 무손실 마이그레이션
- 실호출 E2E: `call_tool` → 일자 버킷·언어까지 채워짐

## 배포 후

`backfill-legacy`를 1회 실행해 기존 28건(전부 7/10)을 일자 버킷에 반영합니다. 이후 트래픽은 실시간으로 일자별 집계됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
