### PR TITLE
fix: use flyctl in sync workflow

### DIFF
--- a/.github/workflows/alio-sync.yml
+++ b/.github/workflows/alio-sync.yml
@@ -40,9 +40,9 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
-          fly ssh console --app koica-reg-mcp --command \
+          flyctl ssh console --app koica-reg-mcp --command \
             "rm -rf /tmp/alio-sync-work && mkdir -p /tmp/alio-sync-work && cp /app/alio_sync.py /tmp/alio-sync-work/ && cp -a /app/data /tmp/alio-sync-work/data && cd /tmp/alio-sync-work && python alio_sync.py --fresh --no-build && tar -czf /tmp/alio-sync-data.tar.gz -C /tmp/alio-sync-work/data extracted sources.json"
-          fly ssh sftp get --app koica-reg-mcp \
+          flyctl ssh sftp get --app koica-reg-mcp \
             /tmp/alio-sync-data.tar.gz ./alio-sync-data.tar.gz
           tar -xzf alio-sync-data.tar.gz -C data
 


### PR DESCRIPTION
GitHub Actions의 Fly 설정 액션이 설치하는 실행 파일명인 `flyctl`을 사용하도록 동기화 명령을 수정합니다. actionlint 검사를 통과했습니다.