### PR TITLE
fix: handle Fly machine starting state

### DIFF
--- a/.github/workflows/alio-sync.yml
+++ b/.github/workflows/alio-sync.yml
@@ -43,7 +43,7 @@ jobs:
           MACHINE_ID="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].id')"
           MACHINE_STATE="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].state')"
           test -n "$MACHINE_ID" && test "$MACHINE_ID" != "null"
-          if [ "$MACHINE_STATE" != "started" ]; then
+          if [ "$MACHINE_STATE" = "stopped" ]; then
             flyctl machine start "$MACHINE_ID" --app koica-reg-mcp
           fi
           SSH_READY=false


### PR DESCRIPTION
Fly 머신이 정확히 stopped 상태일 때만 start를 호출하고, starting 상태에서는 SSH 준비 대기로 넘어갑니다. actionlint 검사를 통과했습니다.