### PR TITLE
fix: keep Fly sync machine available

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -23,7 +23,8 @@ primary_region = 'nrt'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  # ALIO 주간 동기화가 SSH로 실행되므로 도쿄 머신 1대는 상시 유지한다.
+  min_machines_running = 1
   processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
ALIO 주간 동기화의 SSH 연결이 auto-stop과 경합하지 않도록 도쿄 shared-cpu 머신 1대를 상시 유지합니다. Fly 설정 검증을 통과했습니다.