### PR TITLE
fix: restore MCP runtime and stream Fly sync

### DIFF
--- a/.github/workflows/alio-sync.yml
+++ b/.github/workflows/alio-sync.yml
@@ -41,26 +41,33 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
           MACHINE_ID="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].id')"
-          MACHINE_STATE="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].state')"
           test -n "$MACHINE_ID" && test "$MACHINE_ID" != "null"
-          if [ "$MACHINE_STATE" = "stopped" ]; then
-            flyctl machine start "$MACHINE_ID" --app koica-reg-mcp
-          fi
-          SSH_READY=false
+          SYNC_COMPLETE=false
           for attempt in $(seq 1 12); do
+            MACHINE_STATE="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].state')"
+            if [ "$MACHINE_STATE" = "stopped" ]; then
+              if ! flyctl machine start "$MACHINE_ID" --app koica-reg-mcp; then
+                MACHINE_STATE="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].state')"
+                test "$MACHINE_STATE" = "starting" -o "$MACHINE_STATE" = "started"
+              fi
+            fi
+            STARTED_AT=$SECONDS
             if flyctl ssh console --app koica-reg-mcp --machine "$MACHINE_ID" \
-              --command "true"; then
-              SSH_READY=true
+              --command "sh -lc 'rm -rf /tmp/alio-sync-work && mkdir -p /tmp/alio-sync-work && cp /app/alio_sync.py /tmp/alio-sync-work/ && cp -a /app/data /tmp/alio-sync-work/data && cd /tmp/alio-sync-work && python alio_sync.py --fresh --no-build && tar -czf /tmp/alio-sync-data.tar.gz -C /tmp/alio-sync-work/data extracted sources.json && base64 -w 0 /tmp/alio-sync-data.tar.gz'" \
+              > alio-sync-data.tar.gz.b64; then
+              SYNC_COMPLETE=true
               break
             fi
-            echo "SSH 준비 대기 ${attempt}/12"
+            ELAPSED=$((SECONDS - STARTED_AT))
+            if [ "$ELAPSED" -ge 30 ]; then
+              echo "Fly 원격 동기화가 시작된 뒤 실패했습니다. 연결 재시도하지 않습니다."
+              exit 1
+            fi
+            echo "SSH 연결 준비 대기 ${attempt}/12"
             sleep 5
           done
-          test "$SSH_READY" = "true"
-          flyctl ssh console --app koica-reg-mcp --machine "$MACHINE_ID" --command \
-            "rm -rf /tmp/alio-sync-work && mkdir -p /tmp/alio-sync-work && cp /app/alio_sync.py /tmp/alio-sync-work/ && cp -a /app/data /tmp/alio-sync-work/data && cd /tmp/alio-sync-work && python alio_sync.py --fresh --no-build && tar -czf /tmp/alio-sync-data.tar.gz -C /tmp/alio-sync-work/data extracted sources.json"
-          flyctl ssh sftp get --app koica-reg-mcp --machine "$MACHINE_ID" \
-            /tmp/alio-sync-data.tar.gz ./alio-sync-data.tar.gz
+          test "$SYNC_COMPLETE" = "true"
+          base64 --decode alio-sync-data.tar.gz.b64 > alio-sync-data.tar.gz
           tar -xzf alio-sync-data.tar.gz -C data
 
       - name: 전체 검색 인덱스 검증

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ COPY data/ ./data/
 # index.json(검색 인덱스)은 빌드 산출물이라 git·저장소에 없다. 따라서 이미지
 # 빌드 시 extracted → index.json 을 직접 생성한다. 이렇게 해야 로컬 `fly deploy`든
 # GitHub Actions 자동배포(저장소 checkout)든 항상 데이터가 포함된다.
-RUN python3 koica_search.py build
+RUN python3 -c "from mcp.server.fastmcp import FastMCP" \
+ && python3 koica_search.py build
 
 ENV PORT=8080
 EXPOSE 8080

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# streamable-http(원격 HTTP) 전송을 위해 1.8+ 필요. FastMCP가 starlette/uvicorn을 함께 끌어온다.
-mcp>=1.8
+# streamable-http 전송을 위해 1.8+ 필요. 2.x는 FastMCP import 경로가 호환되지 않는다.
+mcp>=1.8,<2


### PR DESCRIPTION
mcp 2.0 비호환으로 기동 실패한 서버를 mcp<2로 고정하고 이미지 빌드 시 FastMCP import를 검증합니다. Fly 동기화는 실제 원격 작업을 연결 재시도 대상으로 실행하고 같은 SSH 연결로 결과를 전송합니다. 단위 테스트 10개, actionlint, 원격 이미지 빌드를 통과했습니다.