### PR TITLE
find_references: 조문 미발견을 오류가 아닌 빈 인용 그래프로 반환

### DIFF
--- a/.github/workflows/alio-sync.yml
+++ b/.github/workflows/alio-sync.yml
@@ -41,26 +41,33 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
           MACHINE_ID="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].id')"
-          MACHINE_STATE="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].state')"
           test -n "$MACHINE_ID" && test "$MACHINE_ID" != "null"
-          if [ "$MACHINE_STATE" = "stopped" ]; then
-            flyctl machine start "$MACHINE_ID" --app koica-reg-mcp
-          fi
-          SSH_READY=false
+          SYNC_COMPLETE=false
           for attempt in $(seq 1 12); do
+            MACHINE_STATE="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].state')"
+            if [ "$MACHINE_STATE" = "stopped" ]; then
+              if ! flyctl machine start "$MACHINE_ID" --app koica-reg-mcp; then
+                MACHINE_STATE="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].state')"
+                test "$MACHINE_STATE" = "starting" -o "$MACHINE_STATE" = "started"
+              fi
+            fi
+            STARTED_AT=$SECONDS
             if flyctl ssh console --app koica-reg-mcp --machine "$MACHINE_ID" \
-              --command "true"; then
-              SSH_READY=true
+              --command "sh -lc 'rm -rf /tmp/alio-sync-work && mkdir -p /tmp/alio-sync-work && cp /app/alio_sync.py /tmp/alio-sync-work/ && cp -a /app/data /tmp/alio-sync-work/data && cd /tmp/alio-sync-work && python alio_sync.py --fresh --no-build && tar -czf /tmp/alio-sync-data.tar.gz -C /tmp/alio-sync-work/data extracted sources.json && base64 -w 0 /tmp/alio-sync-data.tar.gz'" \
+              > alio-sync-data.tar.gz.b64; then
+              SYNC_COMPLETE=true
               break
             fi
-            echo "SSH 준비 대기 ${attempt}/12"
+            ELAPSED=$((SECONDS - STARTED_AT))
+            if [ "$ELAPSED" -ge 30 ]; then
+              echo "Fly 원격 동기화가 시작된 뒤 실패했습니다. 연결 재시도하지 않습니다."
+              exit 1
+            fi
+            echo "SSH 연결 준비 대기 ${attempt}/12"
             sleep 5
           done
-          test "$SSH_READY" = "true"
-          flyctl ssh console --app koica-reg-mcp --machine "$MACHINE_ID" --command \
-            "rm -rf /tmp/alio-sync-work && mkdir -p /tmp/alio-sync-work && cp /app/alio_sync.py /tmp/alio-sync-work/ && cp -a /app/data /tmp/alio-sync-work/data && cd /tmp/alio-sync-work && python alio_sync.py --fresh --no-build && tar -czf /tmp/alio-sync-data.tar.gz -C /tmp/alio-sync-work/data extracted sources.json"
-          flyctl ssh sftp get --app koica-reg-mcp --machine "$MACHINE_ID" \
-            /tmp/alio-sync-data.tar.gz ./alio-sync-data.tar.gz
+          test "$SYNC_COMPLETE" = "true"
+          base64 --decode alio-sync-data.tar.gz.b64 > alio-sync-data.tar.gz
           tar -xzf alio-sync-data.tar.gz -C data
 
       - name: 전체 검색 인덱스 검증

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ COPY data/ ./data/
 # index.json(검색 인덱스)은 빌드 산출물이라 git·저장소에 없다. 따라서 이미지
 # 빌드 시 extracted → index.json 을 직접 생성한다. 이렇게 해야 로컬 `fly deploy`든
 # GitHub Actions 자동배포(저장소 checkout)든 항상 데이터가 포함된다.
-RUN python3 koica_search.py build
+RUN python3 -c "from mcp.server.fastmcp import FastMCP" \
+ && python3 koica_search.py build
 
 ENV PORT=8080
 EXPOSE 8080

--- a/koica_mcp_server.py
+++ b/koica_mcp_server.py
@@ -183,6 +183,10 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             limit: 각 방향 최대 결과 수 (기본 20)
             include_mermaid: True면 반환값에 "mermaid"(flowchart 코드) 포함.
                 claude.ai 등에서 인용망을 바로 시각화할 때 사용.
+
+        Returns:
+            status가 ok / not_found / invalid_article 중 하나. 조문을 찾지 못해도
+            오류가 아니라 빈 그래프(outgoing·incoming 0건)로 반환합니다.
         """
         _usage.record("find_references")
         return ks.find_references(source, article, limit=limit, include_mermaid=include_mermaid)

--- a/koica_search.py
+++ b/koica_search.py
@@ -801,6 +801,32 @@ _EXTERNAL_CITE_RE = re.compile(
 )
 
 
+def _empty_references(source: str, article: str, status: str, note: str,
+                      include_mermaid: bool = False) -> dict:
+    """조문을 찾지 못했을 때의 정상 응답.
+
+    "없음"은 오류가 아니라 결과이므로, 성공 응답과 같은 키 구성을 유지한 채
+    status로만 구분한다. 소비자(공개 게이트웨이 포함)가 응답 형태를 바꾸지
+    않고 그대로 처리할 수 있게 하기 위함이다.
+    """
+    result = {
+        "target": {
+            "source": source,
+            "article": article,
+            "article_title": None,
+            "citation": f"{source} {article}".strip(),
+        },
+        "outgoing": [],
+        "incoming": [],
+        "counts": {"outgoing": 0, "incoming": 0},
+        "status": status,
+        "note": note,
+    }
+    if include_mermaid:
+        result["mermaid"] = _mermaid_graph(result)
+    return result
+
+
 def find_references(source: str, article: str, limit: int = 20,
                     include_mermaid: bool = False) -> dict:
     """대상 조문의 정방향(outgoing) · 역방향(incoming) 인용 관계.
@@ -815,10 +841,17 @@ def find_references(source: str, article: str, limit: int = 20,
 
     include_mermaid=True 이면 반환 dict에 "mermaid" 키로 flowchart 코드를 함께
     담는다 (claude.ai 등에서 인용망을 바로 시각화).
+
+    status는 ok / not_found / invalid_article 중 하나. 조문을 찾지 못한 경우도
+    오류가 아니라 빈 그래프(outgoing·incoming 0건)로 반환한다.
     """
     parsed = _parse_article_token(article)
     if parsed is None:
-        return {"error": f"invalid article token: {article!r}"}
+        return _empty_references(
+            source, article, "invalid_article",
+            f"조문 번호를 해석할 수 없습니다: {article!r}",
+            include_mermaid=include_mermaid,
+        )
     no, sub = parsed
     articles = load_index()
 
@@ -828,7 +861,12 @@ def find_references(source: str, article: str, limit: int = 20,
         if src_ok(a.source) and a.article_no == no and a.article_sub == sub
     ]
     if not targets:
-        return {"error": f"target not found: {source} 제{no}조" + (f"의{sub}" if sub else "")}
+        cite = f"제{no}조" + (f"의{sub}" if sub else "")
+        return _empty_references(
+            source, cite, "not_found",
+            f"인덱스에 없는 조문입니다: {source} {cite}",
+            include_mermaid=include_mermaid,
+        )
 
     # 본칙(비-부칙) 조문을 target으로 우선 — 부칙 제N조 오선택 방지
     targets.sort(key=lambda a: a.is_supplementary)
@@ -945,6 +983,7 @@ def find_references(source: str, article: str, limit: int = 20,
         "outgoing": outgoing[:limit],
         "incoming": incoming[:limit],
         "counts": {"outgoing": len(outgoing), "incoming": len(incoming)},
+        "status": "ok",
     }
     if include_mermaid:
         result["mermaid"] = _mermaid_graph(result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# streamable-http(원격 HTTP) 전송을 위해 1.8+ 필요. FastMCP가 starlette/uvicorn을 함께 끌어온다.
-mcp>=1.8
+# streamable-http 전송을 위해 1.8+ 필요. 2.x는 FastMCP import 경로가 호환되지 않는다.
+mcp>=1.8,<2


### PR DESCRIPTION
## 배경

공개 ODA Intelligence 게이트웨이를 적대적 테스트하던 중, `find_references`로 존재하지 않는 조문을 조회하면 `PUBLIC_RESPONSE_BLOCKED` 오류가 나는 것을 확인했다. 업스트림 원본 응답을 직접 받아 원인을 특정했다.

```
{"error": "target not found: 인사규정 제9999조"}
```

`isError` 플래그가 없어 게이트웨이가 이를 정상 응답으로 취급하고, `target`/`outgoing`/`incoming`/`counts` 스키마 투영에 실패해 응답 전체를 차단했다.

## 변경

"없음"은 오류가 아니라 결과이므로, 성공 응답과 **같은 키 구성**을 유지한 빈 그래프로 반환하고 `status`로만 구분한다. 조문 번호 파싱 실패 경로에도 같은 결함이 있어 함께 고쳤다.

- `status`: `ok` / `not_found` / `invalid_article`
- 미발견 시 `article_title`은 `null`, `counts`는 0

## 확인

```
('인사규정','제9999조') -> not_found
('없는규정','제1조')    -> not_found
('인사규정','!!!')      -> invalid_article
('인사규정','제10조')   -> ok
```

수정된 응답을 게이트웨이 검열 함수에 통과시켜 차단되지 않음을 확인했다. 게이트웨이 쪽 대응 변경은 amnotyoung/io-mcp에서 별도로 진행한다.

> 이 브랜치에는 이번 수정 이전의 `fix: restore MCP runtime and stream Fly sync` 커밋이 함께 포함돼 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)