### PR TITLE
feat: add hybrid regulation search

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,13 +23,16 @@ data/_cache/
 # 시험문제 데이터 (출처 불명 → 공개 원격 서버에서 제외)
 data/questions.json
 
-# 인덱스는 이미지 빌드 단계(RUN … build)에서 생성하므로 로컬 산출물은 제외 (항상 재생성)
+# 인덱스와 의미 검색 모델은 이미지 빌드 단계에서 생성·복사하므로 로컬 산출물은 제외
+# (항상 현재 코드·규정 데이터 및 고정된 모델 리비전으로 재생성)
 data/index.json
+data/semantic_vectors.npy
+data/semantic_meta.json
+data/.semantic_*.tmp
+data/semantic_model/
 
-# 로컬 전용 문서 (alio_sync.py는 Fly 도쿄 동기화 작업에 사용)
+# 로컬 전용 안내 문서 (LICENSE·NOTICE는 이미지에 포함해 모델 출처를 보존)
 README.md
-LICENSE
-NOTICE
 AGENTS.md
 CLAUDE.md
 

--- a/.github/workflows/alio-sync.yml
+++ b/.github/workflows/alio-sync.yml
@@ -29,6 +29,21 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+
+      - name: 검색 런타임 의존성 설치
+        run: python3 -m pip install --disable-pip-version-check -r requirements.txt
+
+      - name: 의미 검색 모델 캐시
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/koica-semantic-model
+          key: koica-semantic-e5-small-614241f622f53c4eeff9890bdc4f31cfecc418b3
+
+      - name: 의미 검색 모델 준비
+        env:
+          KOICA_SEMANTIC_MODEL_DIR: ${{ runner.temp }}/koica-semantic-model
+        run: python3 semantic_search.py download-model --model-dir "$KOICA_SEMANTIC_MODEL_DIR"
 
       - name: 동기화 안전장치 테스트
         run: python3 -m unittest discover -s tests -v
@@ -42,6 +57,30 @@ jobs:
         run: |
           MACHINE_ID="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].id')"
           test -n "$MACHINE_ID" && test "$MACHINE_ID" != "null"
+          PAUSE_FILE="/data/semantic-search.paused"
+          unpause_semantic() {
+            for cleanup_attempt in 1 2 3; do
+              if flyctl ssh console --app koica-reg-mcp --machine "$MACHINE_ID" \
+                --command "rm -f $PAUSE_FILE"; then
+                return 0
+              fi
+              echo "의미 검색 일시정지 해제 재시도 ${cleanup_attempt}/3"
+              sleep 2
+            done
+            return 1
+          }
+          trap 'unpause_semantic || true' EXIT
+
+          MACHINE_STATE="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].state')"
+          if [ "$MACHINE_STATE" = "stopped" ]; then
+            flyctl machine start "$MACHINE_ID" --app koica-reg-mcp
+          fi
+          flyctl ssh console --app koica-reg-mcp --machine "$MACHINE_ID" \
+            --command "touch $PAUSE_FILE"
+          # 재시작으로 이미 적재된 ONNX 메모리를 비운다. 표식이 유지되는 동안
+          # 공개 요청은 자동으로 기존 키워드 검색을 사용하므로 Node/kordoc와 겹치지 않는다.
+          flyctl machine restart "$MACHINE_ID" --app koica-reg-mcp
+
           SYNC_COMPLETE=false
           for attempt in $(seq 1 12); do
             MACHINE_STATE="$(flyctl machine list --app koica-reg-mcp --json | jq -r '.[0].state')"
@@ -69,10 +108,17 @@ jobs:
           test "$SYNC_COMPLETE" = "true"
           base64 --decode alio-sync-data.tar.gz.b64 > alio-sync-data.tar.gz
           tar -xzf alio-sync-data.tar.gz -C data
+          unpause_semantic
+          trap - EXIT
 
       - name: 전체 검색 인덱스 검증
-        run: python3 koica_search.py build
-        # index.json은 gitignore 대상이라 PR에는 규정 원문과 sources.json만 포함된다.
+        env:
+          KOICA_SEMANTIC_MODEL_DIR: ${{ runner.temp }}/koica-semantic-model
+          KOICA_SEMANTIC_THREADS: "4"
+        run: |
+          python3 koica_search.py build --strict-semantic
+          python3 tests/evaluate_semantic_quality.py
+        # 키워드·의미 인덱스는 gitignore 대상이라 PR에는 규정 원문과 sources.json만 포함된다.
 
       - name: 변경분 PR 생성·자동 병합·배포
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # 빌드 산출물
 data/index.json
+data/semantic_vectors.npy
+data/semantic_meta.json
+data/.semantic_*.tmp
+data/semantic_model/
 
 # 시험문제 데이터 (출처 불명, 별도 보관)
 data/questions.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,14 +42,16 @@ claude mcp add --transport http koica-reg https://koica-reg-mcp.fly.dev/mcp
 git clone https://github.com/amnotyoung/koica-reg-mcp.git
 cd koica-reg-mcp
 pip install -r requirements.txt
-python3 koica_search.py build      # data/extracted → data/index.json
+python3 semantic_search.py download-model
+python3 koica_search.py build --strict-semantic
 ```
 
 - `koica_mcp_server.py` — 로컬 stdio 서버 (도구 11개 = 원격 8개 + `update`·`sync_from_alio`·`find_questions`)
 - `server_http.py` — 원격 HTTP(streamable-http) 서버 (읽기 8개)
 - `Dockerfile` + `fly.toml` — Fly.io 배포. **`main`에 머지되면 GitHub Actions가 자동 재배포**합니다.
-- 검색 엔진(`koica_search.py`)은 순수 표준 라이브러리(런타임 의존성은 `mcp` 하나).
-- 인덱스(`data/index.json`)는 gitignore되며, 이미지 빌드 시 `data/extracted/`에서 생성됩니다.
+- 검색 엔진은 기존 IDF 키워드 점수와 로컬 `intfloat/multilingual-e5-small` ONNX 의미 유사도를 결합합니다. 외부 임베딩 API나 API 키는 쓰지 않습니다.
+- 의미 모델은 고정 리비전·SHA-256을 검증해 사용자 캐시에 받고, `numpy`·`onnxruntime`·`sentencepiece`로 추론합니다. 배포 경로는 `KOICA_SEMANTIC_MODEL_DIR`로 고정할 수 있습니다.
+- `data/index.json`, `data/semantic_vectors.npy`, `data/semantic_meta.json`은 gitignore된 빌드 산출물이며 Docker와 CI에서는 `--strict-semantic`으로 함께 생성·검증합니다.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,4 +23,5 @@ claude mcp add --transport http koica-reg https://koica-reg-mcp.fly.dev/mcp
 상세는 [AGENTS.md](AGENTS.md)와 [README](README.md) 참고.
 - 로컬 stdio: `koica_mcp_server.py`(도구 11개) / 원격 HTTP: `server_http.py`(읽기 8개)
 - 배포: `Dockerfile`+`fly.toml`(Fly.io). `main` 머지 시 자동 재배포.
-- 검색 엔진은 순수 표준 라이브러리(의존성 `mcp`뿐).
+- 검색 엔진은 IDF 키워드 + 로컬 `intfloat/multilingual-e5-small` ONNX 의미 검색을 결합합니다. 외부 임베딩 API는 사용하지 않습니다.
+- 로컬 빌드: `pip install -r requirements.txt` → `python3 semantic_search.py download-model` → `python3 koica_search.py build --strict-semantic`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 # KOICA 규정 MCP — 원격 HTTP 서버 이미지
 FROM node:20-slim AS node_runtime
 
+# 의미 검색 모델은 규정 데이터와 분리된 레이어에 내려받는다. 규정만 갱신된 배포에서는
+# 약 124 MB 모델·토크나이저 레이어를 재사용하며, 다운로드 도구가 고정 리비전·SHA-256을 검증한다.
+FROM python:3.12-slim AS semantic_model
+
+WORKDIR /model-build
+
+COPY semantic_search.py ./
+RUN python3 semantic_search.py download-model --model-dir /opt/koica-semantic-model
+
 FROM python:3.12-slim
 
 WORKDIR /app
@@ -19,17 +28,28 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # 애플리케이션 코드 (server_http → koica_mcp_server → koica_search / usage_stats 의존)
 # stats_cli.py: 소유자 전용 사용량 조회(공개 MCP엔 usage_stats 미노출, fly ssh로만 읽음)
-COPY koica_search.py koica_mcp_server.py server_http.py usage_stats.py stats_cli.py alio_sync.py ./
+COPY koica_search.py semantic_search.py koica_mcp_server.py server_http.py usage_stats.py stats_cli.py alio_sync.py ./
+COPY tests/evaluate_semantic_quality.py ./tests/
+COPY LICENSE NOTICE /usr/share/doc/koica-reg-mcp/
+
+# 공개 서버는 외부 임베딩 API를 호출하지 않는다. 빌드 단계에서 검증한 고정 E5 모델을
+# 복사해 런타임 추론을 완전히 로컬·오프라인으로 수행한다.
+COPY --from=semantic_model /opt/koica-semantic-model /opt/koica-semantic-model
+ENV KOICA_SEMANTIC_MODEL_DIR=/opt/koica-semantic-model
 
 # 데이터: 검색 인덱스 + 규정 본문. _cache(원본 HWP)/시험범위 PDF는 .dockerignore로 제외
 COPY data/ ./data/
 
-# index.json(검색 인덱스)은 빌드 산출물이라 git·저장소에 없다. 따라서 이미지
-# 빌드 시 extracted → index.json 을 직접 생성한다. 이렇게 해야 로컬 `fly deploy`든
-# GitHub Actions 자동배포(저장소 checkout)든 항상 데이터가 포함된다.
+# 검색 인덱스는 빌드 산출물이라 git·저장소에 없다. 이미지 빌드 시 키워드 인덱스와
+# 의미 벡터를 함께 생성하고, 의미 인덱스가 없거나 모델과 맞지 않으면 빌드를 실패시킨다.
+# 이렇게 해야 로컬 `fly deploy`든 자동배포든 항상 실제 하이브리드 검색이 활성화된다.
 RUN python3 -c "from mcp.server.fastmcp import FastMCP" \
- && python3 koica_search.py build
+ && KOICA_SEMANTIC_THREADS=4 python3 koica_search.py build --strict-semantic \
+ && python3 tests/evaluate_semantic_quality.py
 
+# 이미지 빌드에는 네 코어를 쓰되, 512MB 운영 머신에서는 ONNX 단일
+# 추론이 하나의 CPU 스레드만 쓰게 한다. 동시 세션 실행은 DenseEncoder 락이 직렬화한다.
+ENV KOICA_SEMANTIC_THREADS=1
 ENV PORT=8080
 EXPOSE 8080
 

--- a/NOTICE
+++ b/NOTICE
@@ -6,7 +6,7 @@ NOTICE — koica-reg-mcp 라이선스 및 데이터 출처
 
 1. 소프트웨어 (코드)
 --------------------
-koica_search.py, koica_mcp_server.py, server_http.py, alio_sync.py,
+koica_search.py, semantic_search.py, koica_mcp_server.py, server_http.py, alio_sync.py,
 Dockerfile 등 모든 소스코드는 MIT License(→ LICENSE 파일)를 따릅니다.
 Copyright (c) 2026 amnotyoung.
 
@@ -23,7 +23,22 @@ data/extracted/*.md, data/sources.json 등에 담긴 KOICA(한국국제협력단
              KOICA가 ALIO를 통해 공표한 자료를 조문 단위로 추출·정규화한 것입니다.
 
 
-3. 면책 (Disclaimer)
+3. 의미 검색 모델
+-----------------
+하이브리드 검색은 아래의 제3자 사전학습 모델을 로컬 ONNX 추론에 사용합니다.
+모델 파일은 이 Git 저장소에 포함하지 않고 빌드 시 고정 리비전에서 내려받으며,
+SHA-256을 검증합니다.
+
+- 모델     : intfloat/multilingual-e5-small
+- 출처     : https://huggingface.co/intfloat/multilingual-e5-small
+- 리비전   : 614241f622f53c4eeff9890bdc4f31cfecc418b3
+- 라이선스 : MIT License
+
+모델에서 생성한 data/semantic_vectors.npy와 data/semantic_meta.json은 재생성 가능한
+검색 인덱스이며 Git 저장소에 포함하지 않습니다.
+
+
+4. 면책 (Disclaimer)
 --------------------
 - 본 데이터는 참조·연구·업무 보조용입니다.
 - 추출·정규화 과정에서 오류가 있을 수 있으며, 정확성·완전성을 보증하지 않습니다.
@@ -32,7 +47,7 @@ data/extracted/*.md, data/sources.json 등에 담긴 KOICA(한국국제협력단
 - 소프트웨어는 LICENSE의 "AS IS" 조항에 따라 어떠한 보증도 없이 제공됩니다.
 
 
-4. 제외 데이터
+5. 제외 데이터
 --------------
 data/questions.json(시험문제 데이터)은 출처가 불명확하여 공개 원격 배포
 이미지에서 제외됩니다(.dockerignore 참조). 로컬 사용에 한합니다.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # koica-reg-mcp
 
-**KOICA 현행 규정 149개를 MCP로 검색·조회.** 한국국제협력단 내부 규정을 조문 단위 검색 + 본문 직접 조회 + 인용 검증(제목 환각까지) + 상호참조 그래프 + **규정 정비 레이더**로, MCP 호환 클라이언트(Claude Desktop·claude.ai·Claude Code·Codex·Cursor 등)에서 사용. 규정 원본은 [ALIO(공공기관 경영정보 공개시스템)](https://www.alio.go.kr/item/itemOrganList.do?apbaId=C0146&reportFormRootNo=21110)에서 **자동 동기화**됩니다.
+**KOICA 현행 규정 149개를 MCP로 검색·조회.** 한국국제협력단 내부 규정을 **키워드 + 의미 기반 하이브리드 검색** + 본문 직접 조회 + 인용 검증(제목 환각까지) + 상호참조 그래프 + **규정 정비 레이더**로, MCP 호환 클라이언트(Claude Desktop·claude.ai·Claude Code·Codex·Cursor 등)에서 사용. 규정 원본은 [ALIO(공공기관 경영정보 공개시스템)](https://www.alio.go.kr/item/itemOrganList.do?apbaId=C0146&reportFormRootNo=21110)에서 **자동 동기화**됩니다.
 
 [![MCP](https://img.shields.io/badge/MCP-streamable--http-blue)](https://modelcontextprotocol.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -43,16 +43,22 @@ https://koica-reg-mcp.fly.dev/mcp
 ## 무엇을 해결하나
 
 - **참조 시간 단축** — 149개 규정을 매번 열어 Ctrl+F 하는 대신, 자연어 한 줄로 조문 단위 검색
+- **표현이 달라도 검색** — 정확한 규정 용어를 몰라도 로컬 multilingual-E5 의미 검색이 의역·유사 표현의 후보 조문을 보완
 - **항상 현행본** — ALIO의 KOICA 규정 목록을 주기적으로 자동 수집해 **최신 개정본**만 인덱싱
 - **인용 검증** — 보고서·답변에 들어간 "{규정명} 제N조" 인용이 실제로 존재하는지 자동 교차검증 (LLM 환각 방지)
 - **상호참조 자동 추적** — 어떤 조문이 시행세칙·관련 지침의 어디로 연결되는지 양방향 그래프
 - **시험 준비 보조** — KOICA 채용·승진 시험 응시자가 자기 정답을 근거 조문으로 검증
 
+이 서버 자체가 답변 문장을 생성하는 RAG 애플리케이션은 아닙니다. MCP 서버는 관련
+조문을 검색·조회해 근거를 반환하고, 연결한 Claude·Codex 등의 클라이언트 LLM이 그
+근거로 답변을 작성합니다. 즉 전체 사용 흐름에서는 RAG의 **검색(retrieval) 계층**을
+담당하며, 생성 모델이나 외부 임베딩 API를 서버 안에 두지 않습니다.
+
 ---
 
-## 인덱싱 범위 (현행 규정 149개, 약 6,392개 조문 = 본칙 4,202 + 부칙 2,190)
+## 인덱싱 범위 (현행 규정 149개, 약 6,400개 조문)
 
-ALIO의 KOICA 규정 목록(`apbaId=C0146`)에 게시된 **현행 규정 전체**를 자동 수집합니다. 별도의 "분야" 분류 대신, 규정명으로 곧바로 찾도록 설계했습니다 — 주 사용 축은 **규정명(`source`) + 본문 전문검색**입니다.
+ALIO의 KOICA 규정 목록(`apbaId=C0146`)에 게시된 **현행 규정 전체**를 자동 수집합니다. 별도의 "분야" 분류 대신, 규정명으로 곧바로 찾도록 설계했습니다 — 주 사용 축은 **규정명(`source`) + 키워드·의미 하이브리드 검색**입니다.
 
 | 규정 유형 | 규정 수 | 예시 |
 |---|---|---|
@@ -79,19 +85,23 @@ ALIO의 KOICA 규정 목록(`apbaId=C0146`)에 게시된 **현행 규정 전체*
 
 ### 1. 설치
 
+Python 3.11 이상이 필요합니다.
+
 ```bash
 git clone https://github.com/amnotyoung/koica-reg-mcp.git
 cd koica-reg-mcp
 pip install -r requirements.txt
-python3 koica_search.py build
+python3 semantic_search.py download-model
+python3 koica_search.py build --strict-semantic
 ```
 
-빌드가 끝나면 `data/index.json`에 약 6,392개 조문 + 1,312개 별표·별지가 인덱싱됩니다. (본칙 조문은 부칙과 분리 태깅되어 조회 시 본칙이 우선됩니다.)
+현재 추출본 기준으로 빌드하면 `data/index.json`에 6,396개 조문(본칙 4,200 + 부칙 2,196)과 1,313개 별표·별지가 인덱싱되고, `data/semantic_vectors.npy`와 `data/semantic_meta.json`에 의미 검색 인덱스가 생성됩니다. 최초 한 번 약 124MB의 고정 multilingual-E5 모델을 사용자 캐시(`~/.cache/koica-reg-mcp/multilingual-e5-small`, 운영체제에 따라 다름)에 내려받습니다. 모델 추론은 로컬에서 실행되며 검색어를 외부 API로 보내지 않습니다. (본칙 조문은 부칙과 분리 태깅되어 조회 시 본칙이 우선됩니다.)
 
 ### 2. CLI로 바로 써보기
 
 ```bash
 python3 koica_search.py search "인사위원회 구성" --source 인사규정
+python3 koica_search.py search "아이 때문에 몇 달 회사를 쉬고 싶다" --mode hybrid
 python3 koica_search.py get "인사규정" "제11조"
 python3 koica_search.py verify "인사규정 제11조에 따라 인사위원회를 둔다"
 python3 koica_search.py refs "직제규정" "제9조"
@@ -153,7 +163,7 @@ codex mcp list
 
 | 도구 | 입력 | 반환 |
 |---|---|---|
-| `search_regulation` | `query, category?, source?, limit?, fuzzy?, include_attachments?` | 조문 단위 검색 (`fuzzy`=음절 bi-gram, `include_attachments`=별표·별지 포함) |
+| `search_regulation` | `query, category?, source?, limit?, fuzzy?, include_attachments?, mode?` | 조문 단위 하이브리드 검색 (`mode`=`hybrid`(기본)/`keyword`/`semantic`, `fuzzy`=키워드 음절 bi-gram, `include_attachments`=별표·별지 포함) |
 | `get_article` | `source, article` | 정확한 조문 본문 전체 |
 | `verify_citation` | `text` | 인용 실재성 검증 + **제목 환각 탐지**(존재하는 조문에 엉뚱한 제목 → `content_mismatch`) |
 | `find_references` | `source, article, include_mermaid?` | 정방향·역방향 인용 관계 (`include_mermaid`=flowchart 코드 동봉) |
@@ -166,6 +176,7 @@ codex mcp list
 | `list_sources` | `category?` | 인덱싱된 규정 목록과 조문 수 |
 
 > `category`는 규정 유형(규정/시행세칙/지침/기준/정관) 필터입니다. 대부분은 `source`(규정명)나 본문 검색이 더 정확합니다.
+> 의미 모델이나 의미 인덱스를 열 수 없으면 `hybrid` 검색은 요청을 실패시키지 않고 기존 키워드 검색으로 자동 전환하며, 결과의 `search_mode`가 `keyword_fallback`으로 표시됩니다.
 
 ---
 
@@ -198,11 +209,14 @@ compliance_radar()  →  정비 검토 대상 (예시)
 ALIO가 해외 GitHub-hosted runner의 연결을 제한하므로 원문 수집·HWP 변환은
 도쿄 Fly.io 머신의 임시 작업공간에서 수행합니다. 검증된 결과만 GitHub Actions로
 가져오며 운영 중인 MCP 데이터 파일을 직접 수정하지 않습니다.
+동기화 직전 의미 검색 일시정지 표식을 만들고 머신을 재시작해 ONNX 메모리를
+비웁니다. 변환 중 들어오는 요청은 키워드 검색으로 자동 폴백하며, 완료 시 표식을
+제거합니다. 비정상 종료로 표식이 남아도 2시간 뒤 의미 검색이 자동 복구됩니다.
 
 동기화에는 네트워크 재시도와 데이터 손실 안전장치가 적용됩니다. ALIO 응답이나
 문서 변환 결과가 기존 규정 수의 90% 미만이면 기존 데이터를 교체하지 않고 실행을
 실패시킵니다. 기존 규정 삭제, 중복 규정명, 개정일 역행도 자동 병합하지 않으며,
-전체 검색 인덱스 빌드가 성공해야 반영됩니다.
+키워드·의미 검색 인덱스의 엄격 빌드가 모두 성공해야 반영됩니다.
 
 ### ② 사용자 직접 — `sync_from_alio` 도구 / CLI
 
@@ -220,7 +234,7 @@ python3 alio_sync.py --fresh  # 캐시 무시하고 처음부터
 Claude Desktop 채팅에서 "koica 도구 최신으로 업데이트해줘" → `update` 도구가 `git pull + 재빌드`를 자동 실행합니다. 데이터만 바뀐 경우 재시작 없이 즉시 반영, `.py`가 바뀐 경우 OS별 재시작 안내가 함께 출력됩니다.
 
 **동기화 파이프라인** (`alio_sync.py`):
-`ALIO 목록 조회 → 각 규정의 현행본(최신 개정본) 해석 → HWP 다운로드 → kordoc로 Markdown 추출 → Format A 정규화 → data/extracted/*.md + sources.json → 인덱스 재빌드`
+`ALIO 목록 조회 → 각 규정의 현행본(최신 개정본) 해석 → HWP 다운로드 → kordoc로 Markdown 추출 → Format A 정규화 → data/extracted/*.md + sources.json → 키워드·의미 인덱스 재빌드`
 
 ---
 
@@ -234,12 +248,17 @@ data/
 │   ├── 시행세칙_인사규정 시행세칙.md
 │   └── 정관_한국국제협력단 정관.md
 ├── sources.json                # 규정 매니페스트 (이름·유형·개정일·fileNo·origin)
-├── index.json                  # 빌드 산출물 (gitignored)
+├── index.json                  # 조문·별표 키워드 인덱스 (빌드 산출물, gitignored)
+├── semantic_vectors.npy        # 조문·별표 검색 청크 의미 벡터 (빌드 산출물, gitignored)
+├── semantic_meta.json          # 모델·본문 해시 및 벡터 메타데이터 (gitignored)
 └── _cache/                     # 동기화 캐시: HWP·원시 md (gitignored)
 alio_sync.py                    # ALIO 동기화 파이프라인
 koica_search.py                 # 인덱싱·검색 엔진 + CLI
-koica_mcp_server.py             # MCP 서버 (10개 도구)
+semantic_search.py              # E5 모델 다운로드·검증·ONNX 추론·벡터 인덱싱
+koica_mcp_server.py             # 로컬 stdio MCP 서버 (11개 도구)
 ```
+
+의미 모델은 기본적으로 저장소 밖의 사용자 캐시에 보관됩니다. 위치를 고정해야 하는 배포 환경은 `KOICA_SEMANTIC_MODEL_DIR`로 지정할 수 있으며, Docker 이미지는 `/opt/koica-semantic-model`을 사용합니다. 저메모리 운영 환경에서 배치 작업과 겹치지 않게 하려면 `KOICA_SEMANTIC_PAUSE_FILE`에 일시정지 표식 경로를 지정할 수 있습니다.
 
 ---
 
@@ -260,13 +279,17 @@ KOICA 규정에 자주 등장하는 외부 법령(공공기관운영법, 국제�
 
 ## 기술 메모
 
-- **검색 엔진**: 순수 Python + 표준 라이브러리 (의존성: `mcp` 패키지 하나)
+- **검색 엔진**: 키워드 점수와 multilingual-E5 의미 유사도를 순위 융합하는 하이브리드 검색
+- **로컬 의미 모델**: [`intfloat/multilingual-e5-small`](https://huggingface.co/intfloat/multilingual-e5-small) ONNX 양자화 모델(고정 리비전·SHA-256 검증). 외부 임베딩 API나 API 키 불필요
+- **런타임 의존성**: `mcp` + 고정 버전 `numpy`·`onnxruntime`·`sentencepiece` (PyTorch·Transformers·벡터 DB 없음)
 - **동기화**: `alio_sync.py` — ALIO REST(JSON) 조회 + [`kordoc`](https://www.npmjs.com/package/kordoc)(HWP→Markdown, Node) + Format A 정규화
 - **macOS NFD 자모 분해** 자동 정규화
 - **두 가지 추출 포맷 지원**: 마크다운 정형(`### 제N조`) 및 평문 PDF(`제N조(...) ...`)
-- **검색 알고리즘**: 한국어 stopword 제거 + 토큰 IDF 가중 substring 매칭 + 음절 bi-gram fuzzy
+- **검색 알고리즘**: 한국어 stopword·토큰 IDF substring·음절 bi-gram fuzzy의 키워드 검색 + KOICA 도메인 표현 보강 + 384차원 E5 코사인 유사도 + reciprocal-rank fusion(각 채널 1위 보존)
 - **별표·별지 분리 인덱싱**: 본문 조문 검색에서 서식·기준표 노이즈 제거
-- **인덱스 캐싱**: MCP 서버 시작 시 전 조문을 메모리에 로드, 매 호출 시 재사용
+- **인덱스 안전성**: 모델 리비전·본문 해시·벡터 차원을 검증해 오래되거나 다른 본문의 의미 인덱스를 사용하지 않음
+- **인덱스 캐싱**: 조문은 메모리에, 의미 벡터는 NumPy 메모리맵으로 로드해 매 호출 시 재사용
+- **배포 품질 게이트**: 규정 용어를 그대로 쓰지 않은 한국어 의역 15건의 Recall@10과 키워드 대비 개선폭을 이미지·동기화 빌드마다 검증
 
 ---
 
@@ -280,12 +303,14 @@ KOICA 규정에 자주 등장하는 외부 법령(공공기관운영법, 국제�
 - [x] v2.1 — **규정 정비 레이더**(`compliance_radar`): 시행세칙·지침 vs 모규정 개정 대조. `verify_citation` 제목 환각 탐지(`content_mismatch`). `find_references` mermaid 그래프 출력. 자동 동기화를 PR 방식으로 전환(브랜치 보호 대응) + kordoc 버전 고정.
 - [x] v2.2 — **정확성 대수술**(적대적 검토 반영): 인라인 본문 조문 대량 누락 수정(3,831→6,392 조문, +67%), 부칙(附則) 네임스페이스 분리로 조번호 충돌 해소, source 정확일치 우선(형제 규정 오혼입 차단), verify 제목검증 강화(환각 미탐·정의구 오탐 수정), 정비 레이더 정규화(미탐 12→15) + no_parent 노출, 별표 라벨 경계 매칭.
 - [x] v2.3 — **원격 MCP 서버**(`server_http.py`, FastMCP streamable-http): Fly.io 배포로 설치 없이 커넥터 URL 하나(`https://koica-reg-mcp.fly.dev/mcp`)로 연결. 공개판은 읽기 8개 도구 노출(관리·시험문제 제외), 로컬 stdio는 전체 11개 유지.
+- [x] v2.4 — **하이브리드 검색**: 기존 IDF 키워드 검색과 로컬 multilingual-E5 의미 검색을 순위 융합해, 규정 원문과 워딩이 다른 자연어 질의의 재현율 개선. 모델·벡터 해시 검증과 키워드 자동 폴백 포함.
 
 ---
 
 ## 라이센스
 
 - **코드**: MIT License (→ [LICENSE](LICENSE)). Copyright (c) 2026 amnotyoung.
+- **의미 검색 모델**: [`intfloat/multilingual-e5-small`](https://huggingface.co/intfloat/multilingual-e5-small), MIT License. 저장소에는 모델 파일을 커밋하지 않으며 빌드 시 고정 리비전을 검증해 내려받습니다.
 - **규정 데이터**(`data/extracted/*.md` 등): MIT 적용 대상이 **아닙니다.** 원저작권은 **한국국제협력단(KOICA)**에 있으며, KOICA가 [ALIO 공공기관 경영정보 공개시스템](https://www.alio.go.kr/item/itemOrganList.do?apbaId=C0146&reportFormRootNo=21110)을 통해 공표한 자료를 조문 단위로 추출·정규화한 것입니다. 이용 근거는 「저작권법」 제24조의2(공공저작물의 자유이용) 및 공공데이터 이용입니다.
 
 코드·데이터의 구분, 출처, 면책은 [NOTICE](NOTICE)에 정리돼 있습니다.

--- a/alio_sync.py
+++ b/alio_sync.py
@@ -7,7 +7,7 @@
     4) kordoc CLI로 HWP → Markdown 일괄 변환
     5) 기존 파서(koica_search)가 먹는 Format A로 정규화
     6) data/extracted/{유형}_{규정명}.md 기록 + sources.json 매니페스트
-    7) 인덱스 재빌드 (data/index.json)
+    7) 키워드·의미 인덱스 재빌드
 
 사용:
     python3 alio_sync.py            # 전체 동기화 (캐시 활용)
@@ -527,6 +527,7 @@ def main() -> None:
         log("[7/7] 인덱스 재빌드 생략 (--no-build)")
     else:
         log("[7/7] 인덱스 재빌드…")
+        os.environ.setdefault("KOICA_SEMANTIC_THREADS", "4")
         import koica_search as ks
         arts, atts = ks.build_index()
         log(f"완료: {len(arts)}개 조문 + {len(atts)}개 별표·별지")

--- a/fly.toml
+++ b/fly.toml
@@ -10,6 +10,8 @@ primary_region = 'nrt'
 # 이 env는 Fly 배포에만 존재하므로 로컬/도커 기본 실행에서는 집계가 꺼진다(no-op).
 [env]
   KOICA_STATS_DB = '/data/usage.db'
+  # 주간 ALIO 변환 중에는 이 표식으로 ONNX 적재를 막고 키워드 검색으로 폴백한다.
+  KOICA_SEMANTIC_PAUSE_FILE = '/data/semantic-search.paused'
 
 # 영속 볼륨. 최초 1회 생성 필요:
 #   fly volumes create koica_data --region nrt --size 1 --app koica-reg-mcp

--- a/koica_mcp_server.py
+++ b/koica_mcp_server.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from typing import Optional
+from typing import Literal, Optional
 
 from mcp.server.fastmcp import FastMCP
 
@@ -69,6 +69,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
         limit: int = 10,
         fuzzy: bool = False,
         include_attachments: bool = False,
+        mode: Literal["hybrid", "keyword", "semantic"] = "hybrid",
     ) -> list[dict]:
         """KOICA 현행 규정을 조문 단위로 검색 — KOICA 사내 규정 질문의 첫 진입점.
 
@@ -88,6 +89,9 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             include_attachments: 별표·별지도 검색 대상에 포함 (기본 False).
                 행정처분 기준표·서식 등을 찾을 때만 켜세요. 일반 조문 검색에서는
                 별표·별지가 결과 품질을 떨어뜨릴 수 있어 기본은 OFF.
+            mode: 검색 방식. "hybrid"(기본)는 키워드 전문검색과 다국어 의미
+                검색을 결합해 표현이 달라도 관련 조문을 찾는다. "keyword"는
+                기존 정확·부분 문자열 검색만, "semantic"은 의미 검색만 사용.
 
         Returns:
             결과 배열. 항목의 type 필드로 "article"/"attachment" 구분.
@@ -102,6 +106,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
             limit=limit,
             fuzzy=fuzzy,
             include_attachments=include_attachments,
+            mode=mode,
         )
 
     @mcp.tool()
@@ -284,7 +289,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
         return ks.self_update()
 
     @mcp.tool()
-    def sync_from_alio(timeout_sec: int = 1200) -> dict:
+    def sync_from_alio(timeout_sec: int = 3600) -> dict:
         """ALIO(alio.go.kr)에서 KOICA 현행 규정을 직접 받아 최신으로 동기화.
 
         공공기관 경영정보 공개시스템의 KOICA 규정 목록(apbaId=C0146,
@@ -299,7 +304,7 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
           - 데이터만 갱신되므로 클라이언트 재시작 없이 즉시 반영됩니다.
 
         Args:
-            timeout_sec: 최대 대기 시간(초, 기본 1200). 초과 시 오류 반환.
+            timeout_sec: 최대 대기 시간(초, 기본 3600). 초과 시 오류 반환.
 
         Returns:
             동기화 결과 요약(규정 수·조문 수, 실행 로그 tail).
@@ -337,6 +342,13 @@ def register_tools(mcp: FastMCP, include_admin: bool = True,
         # 데이터만 바뀌었으므로 인메모리 인덱스 캐시만 무효화 → 재시작 불필요
         ks._INDEX_CACHE = None
         ks._ATTACHMENT_CACHE = None
+        try:
+            import semantic_search
+
+            semantic_search.reset_caches()
+        except Exception:
+            # 키워드 전용 설치에서도 동기화 자체는 계속 성공해야 한다.
+            pass
         arts = ks.load_index()
         return {
             "status": "ok",

--- a/koica_search.py
+++ b/koica_search.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import platform
 import re
 import subprocess
@@ -23,6 +24,8 @@ from typing import Optional
 ROOT = Path(__file__).parent
 DATA_DIR = ROOT / "data" / "extracted"
 INDEX_PATH = ROOT / "data" / "index.json"
+SEMANTIC_VECTORS_PATH = ROOT / "data" / "semantic_vectors.npy"
+SEMANTIC_META_PATH = ROOT / "data" / "semantic_meta.json"
 
 CATEGORY_AGGREGATE_FILES = {
     "law.md", "hr.md", "project.md", "volunteer.md",
@@ -362,7 +365,10 @@ def parse_md(path: Path, category: str) -> tuple[list[Article], list[Attachment]
     return articles, attachments
 
 
-def build_index() -> tuple[list[Article], list[Attachment]]:
+def build_index(
+    build_semantic: bool = True,
+    strict_semantic: bool = False,
+) -> tuple[list[Article], list[Attachment]]:
     if not DATA_DIR.exists():
         raise FileNotFoundError(f"data 폴더 없음: {DATA_DIR}")
     articles: list[Article] = []
@@ -392,6 +398,41 @@ def build_index() -> tuple[list[Article], list[Attachment]]:
         f"빌드: {len(articles)}개 조문 + {len(attachments)}개 별표·별지 / 합본 스킵 {len(skipped)}개 → {INDEX_PATH}",
         file=sys.stderr,
     )
+
+    global _INDEX_CACHE, _ATTACHMENT_CACHE
+    _INDEX_CACHE = None
+    _ATTACHMENT_CACHE = None
+
+    if build_semantic:
+        try:
+            import semantic_search
+
+            metadata = semantic_search.build_semantic_index(
+                articles,
+                attachments,
+                index_path=INDEX_PATH,
+                vectors_path=SEMANTIC_VECTORS_PATH,
+                meta_path=SEMANTIC_META_PATH,
+            )
+            print(
+                f"의미 인덱스: {metadata['vector_count']}개 청크 → {SEMANTIC_VECTORS_PATH}",
+                file=sys.stderr,
+            )
+        except Exception as exc:
+            # 개발 환경에서 선택 의존성/모델이 없더라도 기존 키워드 검색은 유지한다.
+            # 배포 이미지는 --strict-semantic으로 빌드하므로 이 경로를 허용하지 않는다.
+            try:
+                import semantic_search
+
+                semantic_search.reset_caches()
+            except Exception:
+                pass
+            if strict_semantic:
+                raise RuntimeError(f"의미 인덱스 빌드 실패: {exc}") from exc
+            print(
+                f"경고: 의미 인덱스를 만들지 못해 키워드 검색만 사용합니다: {exc}",
+                file=sys.stderr,
+            )
     return articles, attachments
 
 
@@ -537,6 +578,159 @@ def make_snippet(body: str, pos: int, span: int = 80) -> str:
     return s
 
 
+HYBRID_CANDIDATE_LIMIT = 50
+RRF_K = 60
+# 두 채널을 같은 비중으로 결합해야 의미 후보와 정확 키워드 후보가 모두 상위권에
+# 남는다. 한쪽 가중치를 과도하게 높이면 다른 채널의 단독 후보가 사실상 사라진다.
+SEMANTIC_RRF_WEIGHT = 1.0
+SEARCH_MODES = {"hybrid", "keyword", "semantic"}
+_SEMANTIC_WARNING_EMITTED = False
+
+
+def _attachment_score(
+    attachment: Attachment,
+    tokens: list[str],
+    idf: dict[str, float],
+) -> tuple[float, int]:
+    score = 0.0
+    first_pos = -1
+    for token in tokens:
+        weight = idf.get(token, 1.0)
+        if token in attachment.title:
+            score += 5.0 * weight
+        count = attachment.body.count(token)
+        if count:
+            score += float(count) * weight
+            position = attachment.body.find(token)
+            if first_pos < 0 or position < first_pos:
+                first_pos = position
+    return score, first_pos
+
+
+def _rrf_fuse(
+    keyword_keys: list[tuple[str, int]],
+    semantic_keys: list[tuple[str, int]],
+    *,
+    k: int = RRF_K,
+    semantic_weight: float = SEMANTIC_RRF_WEIGHT,
+) -> list[tuple[tuple[str, int], float]]:
+    """Fuse two ranked lists without comparing their incompatible raw scores."""
+
+    fused: dict[tuple[str, int], float] = {}
+    first_seen: dict[tuple[str, int], tuple[int, int]] = {}
+    for rank, key in enumerate(keyword_keys, 1):
+        fused[key] = fused.get(key, 0.0) + 1.0 / (k + rank)
+        first_seen.setdefault(key, (0, rank))
+    for rank, key in enumerate(semantic_keys, 1):
+        fused[key] = fused.get(key, 0.0) + semantic_weight / (k + rank)
+        first_seen.setdefault(key, (1, rank))
+    return sorted(
+        fused.items(),
+        key=lambda row: (-row[1], first_seen[row[0]], row[0]),
+    )
+
+
+def _preserve_channel_heads(
+    ranked: list[tuple[tuple[str, int], float]],
+    keyword_keys: list[tuple[str, int]],
+    semantic_keys: list[tuple[str, int]],
+    *,
+    limit: int,
+) -> list[tuple[tuple[str, int], float]]:
+    """Keep each channel's first hit when at least two result slots exist.
+
+    RRF correctly rewards candidates found by both channels, but many consensus
+    hits can otherwise push a semantic-only paraphrase (or an exact keyword-only
+    citation) just outside a small result window.  Reserving one slot for each
+    channel head preserves both recall paths without changing their RRF scores.
+    """
+
+    selected = list(ranked[:limit])
+    if limit < 2 or not keyword_keys or not semantic_keys:
+        return selected
+
+    required = list(dict.fromkeys((keyword_keys[0], semantic_keys[0])))
+    if len(required) < 2:
+        return selected
+    score_by_key = dict(ranked)
+    selected_keys = {key for key, _score in selected}
+    for required_key in required:
+        if required_key in selected_keys:
+            continue
+        replace_at = next(
+            (
+                index
+                for index in range(len(selected) - 1, -1, -1)
+                if selected[index][0] not in required
+            ),
+            None,
+        )
+        if replace_at is None:
+            break
+        selected_keys.discard(selected[replace_at][0])
+        selected[replace_at] = (required_key, score_by_key[required_key])
+        selected_keys.add(required_key)
+
+    original_rank = {key: index for index, (key, _score) in enumerate(ranked)}
+    selected.sort(key=lambda row: original_rank[row[0]])
+    return selected
+
+
+def _search_result(
+    *,
+    key: tuple[str, int],
+    item: Article | Attachment,
+    position: int,
+    score: float,
+    search_mode: str,
+    keyword_score: Optional[float],
+    semantic_score: Optional[float],
+) -> dict:
+    score_digits = (
+        2
+        if search_mode.startswith("keyword")
+        else 4
+        if search_mode == "semantic"
+        else 6
+    )
+    common = {
+        "type": key[0],
+        "category": item.category,
+        "source": item.source,
+        "revision": item.revision,
+        "citation": item.citation,
+        "snippet": make_snippet(item.body, position),
+        "score": round(score, score_digits),
+        "search_mode": search_mode,
+        "matched_by": (
+            "hybrid"
+            if keyword_score is not None and semantic_score is not None
+            else "keyword"
+            if keyword_score is not None
+            else "semantic"
+        ),
+        "keyword_score": round(keyword_score, 2) if keyword_score is not None else None,
+        "semantic_score": round(semantic_score, 4) if semantic_score is not None else None,
+    }
+    if key[0] == "article":
+        article = item
+        assert isinstance(article, Article)
+        return {
+            **common,
+            "chapter": article.chapter,
+            "article": article.article,
+            "article_title": article.article_title,
+        }
+    attachment = item
+    assert isinstance(attachment, Attachment)
+    return {
+        **common,
+        "kind": attachment.kind,
+        "label": attachment.label,
+        "title": attachment.title,
+    }
+
+
 def search(
     query: str,
     category: Optional[str] = None,
@@ -544,77 +738,157 @@ def search(
     limit: int = 10,
     fuzzy: bool = False,
     include_attachments: bool = False,
+    mode: str = "hybrid",
 ) -> list[dict]:
-    articles = load_index()
-    tokens = tokenize(query)
-    if not tokens:
+    """Search regulations with keyword, semantic, or fused hybrid retrieval.
+
+    ``hybrid`` is the default.  If the optional model or dense artifacts are not
+    available, it degrades to the exact same keyword ranking and labels the response
+    ``keyword_fallback`` rather than failing the MCP request.
+    """
+
+    global _SEMANTIC_WARNING_EMITTED
+    normalized_mode = mode.lower().strip()
+    if normalized_mode not in SEARCH_MODES:
+        choices = ", ".join(sorted(SEARCH_MODES))
+        raise ValueError(f"mode는 다음 중 하나여야 합니다: {choices}")
+    if not query.strip() or limit <= 0:
         return []
-    idf = compute_idf(tokens, articles)
 
-    scored: list[tuple] = []
-    for a in articles:
-        if category and a.category != category:
-            continue
-        if source and not source_match(source, a.source):
-            continue
-        sc, pos = score_article(a, tokens, idf, fuzzy=fuzzy)
-        if sc <= 0:
-            continue
-        scored.append((sc, pos, "article", a))
+    articles = load_index()
+    attachments = load_attachments()
+    article_allowed = [
+        (not category or article.category == category)
+        and (not source or source_match(source, article.source))
+        for article in articles
+    ]
+    attachment_allowed = [
+        include_attachments
+        and not attachment.deleted
+        and (not category or attachment.category == category)
+        and (not source or source_match(source, attachment.source))
+        for attachment in attachments
+    ]
 
-    if include_attachments:
-        for a in load_attachments():
-            if a.deleted:
-                continue
-            if category and a.category != category:
-                continue
-            if source and not source_match(source, a.source):
-                continue
-            sc = 0.0
-            pos = -1
-            for tok in tokens:
-                w = idf.get(tok, 1.0)
-                if tok in a.title:
-                    sc += 5.0 * w
-                cnt = a.body.count(tok)
-                if cnt:
-                    sc += float(cnt) * w
-                    p = a.body.find(tok)
-                    if pos < 0 or p < pos:
-                        pos = p
-            if sc > 0:
-                scored.append((sc, pos, "attachment", a))
+    candidate_limit = max(limit, HYBRID_CANDIDATE_LIMIT)
 
-    scored.sort(key=lambda r: r[0], reverse=True)
-    out = []
-    for sc, pos, kind, item in scored[:limit]:
-        if kind == "article":
-            out.append({
-                "type": "article",
-                "category": item.category,
-                "source": item.source,
-                "revision": item.revision,
-                "chapter": item.chapter,
-                "article": item.article,
-                "article_title": item.article_title,
-                "citation": item.citation,
-                "snippet": make_snippet(item.body, pos),
-                "score": round(sc, 2),
-            })
-        else:
-            out.append({
-                "type": "attachment",
-                "category": item.category,
-                "source": item.source,
-                "revision": item.revision,
-                "kind": item.kind,
-                "label": item.label,
-                "title": item.title,
-                "citation": item.citation,
-                "snippet": make_snippet(item.body, pos),
-                "score": round(sc, 2),
-            })
-    return out
+    def rank_keyword() -> list[tuple[float, int, tuple[str, int]]]:
+        tokens = tokenize(query)
+        if not tokens:
+            return []
+        idf = compute_idf(tokens, articles)
+        rows: list[tuple[float, int, tuple[str, int]]] = []
+        for item_index, article in enumerate(articles):
+            if not article_allowed[item_index]:
+                continue
+            raw_score, position = score_article(article, tokens, idf, fuzzy=fuzzy)
+            if raw_score > 0:
+                rows.append((raw_score, position, ("article", item_index)))
+
+        for item_index, attachment in enumerate(attachments):
+            if not attachment_allowed[item_index]:
+                continue
+            raw_score, position = _attachment_score(attachment, tokens, idf)
+            if raw_score > 0:
+                rows.append((raw_score, position, ("attachment", item_index)))
+        rows.sort(key=lambda row: row[0], reverse=True)
+        return rows[:candidate_limit]
+
+    # Explicit semantic mode does not tokenize, compute IDF, or scan the corpus unless
+    # dense retrieval actually fails and the documented keyword fallback is needed.
+    keyword_rows = rank_keyword() if normalized_mode in {"hybrid", "keyword"} else []
+
+    semantic_rows: list[dict] = []
+    semantic_failed = False
+    if normalized_mode in {"hybrid", "semantic"}:
+        try:
+            import semantic_search
+
+            semantic_rows = semantic_search.semantic_rank(
+                query,
+                article_allowed=article_allowed,
+                attachment_allowed=attachment_allowed,
+                limit=candidate_limit,
+                index_path=INDEX_PATH,
+                vectors_path=SEMANTIC_VECTORS_PATH,
+                meta_path=SEMANTIC_META_PATH,
+            )
+        except Exception as exc:
+            semantic_failed = True
+            if not _SEMANTIC_WARNING_EMITTED:
+                print(
+                    f"경고: 의미 검색을 사용할 수 없어 키워드 검색으로 대체합니다: {exc}",
+                    file=sys.stderr,
+                )
+                _SEMANTIC_WARNING_EMITTED = True
+
+    if semantic_failed and normalized_mode == "semantic":
+        keyword_rows = rank_keyword()
+
+    keyword_details = {
+        key: {"score": raw_score, "position": position}
+        for raw_score, position, key in keyword_rows
+    }
+
+    semantic_details = {
+        (row["kind"], row["item_index"]): row for row in semantic_rows
+    }
+
+    if normalized_mode == "keyword" or semantic_failed:
+        ranked = [(key, details["score"]) for key, details in keyword_details.items()]
+        effective_mode = "keyword" if normalized_mode == "keyword" else "keyword_fallback"
+    elif normalized_mode == "semantic":
+        ranked = [
+            ((row["kind"], row["item_index"]), row["score"])
+            for row in semantic_rows
+        ]
+        effective_mode = "semantic"
+    else:
+        keyword_keys = list(keyword_details)
+        semantic_keys = [
+            (row["kind"], row["item_index"]) for row in semantic_rows
+        ]
+        ranked = _rrf_fuse(
+            keyword_keys,
+            semantic_keys,
+        )
+        ranked = _preserve_channel_heads(
+            ranked,
+            keyword_keys,
+            semantic_keys,
+            limit=limit,
+        )
+        effective_mode = "hybrid"
+
+    output: list[dict] = []
+    for key, fused_score in ranked[:limit]:
+        kind, item_index = key
+        item: Article | Attachment
+        item = articles[item_index] if kind == "article" else attachments[item_index]
+        keyword_detail = keyword_details.get(key)
+        semantic_detail = semantic_details.get(key)
+        if keyword_detail is not None:
+            position = int(keyword_detail["position"])
+        elif semantic_detail is not None:
+            position = (int(semantic_detail["start"]) + int(semantic_detail["end"])) // 2
+        else:  # Defensive only: every ranked key came from one of the channels.
+            position = -1
+        output.append(
+            _search_result(
+                key=key,
+                item=item,
+                position=position,
+                score=float(fused_score),
+                search_mode=effective_mode,
+                keyword_score=(
+                    float(keyword_detail["score"]) if keyword_detail is not None else None
+                ),
+                semantic_score=(
+                    float(semantic_detail["score"]) if semantic_detail is not None else None
+                ),
+            )
+        )
+    return output
 
 
 ARTICLE_TOKEN_RE = re.compile(r"^\s*(?:제)?(\d+)조?(?:의(\d+))?\s*$")
@@ -1346,6 +1620,35 @@ def self_update() -> dict:
     code_changed = any(f.endswith(".py") for f in changed_files)
     data_changed = any("data/" in f or f.endswith(".md") for f in changed_files)
 
+    # 의미 검색은 선택 의존성을 지연 로드한다. requirements가 갱신된 경우에만
+    # 현재 서버와 같은 Python 환경에 설치해 다음 빌드가 dense artifact도 만들게 한다.
+    if "requirements.txt" in changed_files:
+        try:
+            dependency_result = subprocess.run(
+                [sys.executable, "-m", "pip", "install", "-r", str(ROOT / "requirements.txt")],
+                cwd=str(ROOT),
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                **result,
+                "status": "error",
+                "message": "검색 의존성 설치가 10분 안에 끝나지 않았습니다.",
+            }
+        result["steps"].append({
+            "step": "install dependencies",
+            "returncode": dependency_result.returncode,
+            "output": (dependency_result.stdout + "\n" + dependency_result.stderr).strip(),
+        })
+        if dependency_result.returncode != 0:
+            return {
+                **result,
+                "status": "error",
+                "message": "검색 의존성 설치에 실패했습니다.",
+            }
+
     # 2) build
     prev_count = 0
     if INDEX_PATH.exists():
@@ -1355,7 +1658,15 @@ def self_update() -> dict:
             prev_count = len(raw["articles"]) if isinstance(raw, dict) else len(raw)
         except Exception:
             pass
+    previous_threads = os.environ.get("KOICA_SEMANTIC_THREADS")
+    os.environ["KOICA_SEMANTIC_THREADS"] = "4"
     try:
+        try:
+            import semantic_search
+
+            semantic_search.reset_caches()
+        except Exception:
+            pass
         articles, attachments = build_index()
     except Exception as e:
         return {
@@ -1363,6 +1674,17 @@ def self_update() -> dict:
             "status": "error",
             "message": f"인덱스 빌드 실패: {e}",
         }
+    finally:
+        if previous_threads is None:
+            os.environ.pop("KOICA_SEMANTIC_THREADS", None)
+        else:
+            os.environ["KOICA_SEMANTIC_THREADS"] = previous_threads
+        try:
+            import semantic_search
+
+            semantic_search.reset_caches()
+        except Exception:
+            pass
 
     global _INDEX_CACHE, _ATTACHMENT_CACHE
     _INDEX_CACHE = None
@@ -1393,12 +1715,26 @@ def self_update() -> dict:
     }
 
 
-def cmd_build(_args: argparse.Namespace) -> None:
-    build_index()
+def cmd_build(args: argparse.Namespace) -> None:
+    if args.no_semantic and args.strict_semantic:
+        raise ValueError("--no-semantic과 --strict-semantic은 함께 사용할 수 없습니다.")
+    os.environ.setdefault("KOICA_SEMANTIC_THREADS", "4")
+    build_index(
+        build_semantic=not args.no_semantic,
+        strict_semantic=args.strict_semantic,
+    )
 
 
 def cmd_search(args: argparse.Namespace) -> None:
-    results = search(args.query, args.category, args.source, args.limit, fuzzy=args.fuzzy)
+    results = search(
+        args.query,
+        args.category,
+        args.source,
+        args.limit,
+        fuzzy=args.fuzzy,
+        include_attachments=args.include_attachments,
+        mode=args.mode,
+    )
     if args.json:
         print(json.dumps(results, ensure_ascii=False, indent=2))
         return
@@ -1406,8 +1742,10 @@ def cmd_search(args: argparse.Namespace) -> None:
         print("결과 없음")
         return
     for i, r in enumerate(results, 1):
-        print(f"[{i}] {r['citation']}  ({r['article_title']})  score={r['score']}")
-        print(f"    📂 {r['category']} · {r['chapter']}  · 개정 {r['revision']}")
+        title = r["article_title"] if r["type"] == "article" else r["title"]
+        location = r.get("chapter") or r.get("kind", "")
+        print(f"[{i}] {r['citation']}  ({title})  score={r['score']}")
+        print(f"    📂 {r['category']} · {location}  · 개정 {r['revision']}")
         print(f"    {r['snippet']}")
         print()
 
@@ -1417,6 +1755,13 @@ def main() -> None:
     sub = p.add_subparsers(dest="cmd", required=True)
 
     pb = sub.add_parser("build", help="인덱스 빌드 (data/extracted → data/index.json)")
+    build_mode = pb.add_mutually_exclusive_group()
+    build_mode.add_argument("--no-semantic", action="store_true", help="의미 인덱스 빌드 생략")
+    build_mode.add_argument(
+        "--strict-semantic",
+        action="store_true",
+        help="의미 인덱스 빌드 실패 시 전체 빌드 실패 (배포용)",
+    )
     pb.set_defaults(func=cmd_build)
 
     ps = sub.add_parser("search", help="조문 검색")
@@ -1425,6 +1770,13 @@ def main() -> None:
     ps.add_argument("--source", help="규정명 부분일치 (예: 인사규정)")
     ps.add_argument("--limit", type=int, default=10)
     ps.add_argument("--fuzzy", action="store_true", help="음절 bi-gram 부분 매칭")
+    ps.add_argument("--include-attachments", action="store_true", help="별표·별지도 검색")
+    ps.add_argument(
+        "--mode",
+        choices=sorted(SEARCH_MODES),
+        default="hybrid",
+        help="검색 방식 (기본: hybrid)",
+    )
     ps.add_argument("--json", action="store_true")
     ps.set_defaults(func=cmd_search)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,8 @@
 # streamable-http 전송을 위해 1.8+ 필요. 2.x는 FastMCP import 경로가 호환되지 않는다.
 mcp>=1.8,<2
+
+# 로컬 의미 검색: intfloat/multilingual-e5-small ONNX 추론.
+# Python 3.11·3.12 wheel이 모두 제공되는 버전으로 고정해 로컬/Docker 빌드를 재현한다.
+numpy==2.4.6
+onnxruntime==1.28.0
+sentencepiece==0.2.2

--- a/semantic_search.py
+++ b/semantic_search.py
@@ -1,0 +1,747 @@
+"""Dense semantic indexing and retrieval for KOICA regulations.
+
+The module deliberately keeps heavyweight dependencies lazy.  Commands that only
+use keyword search can therefore still import :mod:`koica_search` without loading
+NumPy, ONNX Runtime, or the embedding model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import threading
+import time
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+
+ROOT = Path(__file__).resolve().parent
+DATA_DIR = ROOT / "data"
+DEFAULT_INDEX_PATH = DATA_DIR / "index.json"
+DEFAULT_VECTORS_PATH = DATA_DIR / "semantic_vectors.npy"
+DEFAULT_META_PATH = DATA_DIR / "semantic_meta.json"
+DEFAULT_PAUSE_MAX_AGE_SEC = 2 * 60 * 60
+
+MODEL_NAME = "intfloat/multilingual-e5-small"
+MODEL_REVISION = "614241f622f53c4eeff9890bdc4f31cfecc418b3"
+MODEL_DIMENSION = 384
+MODEL_FILENAME = "model_qint8_avx512_vnni.onnx"
+TOKENIZER_FILENAME = "sentencepiece.bpe.model"
+MODEL_FILES = {
+    MODEL_FILENAME: (
+        f"https://huggingface.co/{MODEL_NAME}/resolve/{MODEL_REVISION}/"
+        "onnx/model_qint8_avx512_vnni.onnx",
+        "dd476dd0c2514e9b9be83aeb3853fac0763e0bdf4a71645407587d77c48a2d88",
+    ),
+    TOKENIZER_FILENAME: (
+        f"https://huggingface.co/{MODEL_NAME}/resolve/{MODEL_REVISION}/"
+        "sentencepiece.bpe.model",
+        "cfc8146abe2a0488e9e2a0c56de7952f7c11ab059eca145a0a727afce0db2865",
+    ),
+}
+
+SEMANTIC_SCHEMA_VERSION = 1
+CHUNK_SIZE = 400
+CHUNK_OVERLAP = 80
+DEFAULT_BATCH_SIZE = 8
+
+# 자연어와 규정 용어 사이의 간극이 특히 큰 KOICA 인사·복무·계약·정보공개
+# 표현만 보강한다. 원문을 대체하지 않고 E5 질의 뒤에 관련 통제어를 붙이므로,
+# 기존 키워드 채널의 점수와 순위는 전혀 바뀌지 않는다.
+_QUERY_ALIAS_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"(?:아이|자녀).{0,18}(?:돌보|키우|양육|쉬|휴직)"),
+        "자녀 양육 육아휴직",
+    ),
+    (re.compile(r"주말"), "토요일 휴일 유급휴일 무급휴일"),
+    (re.compile(r"(?:피.{0,8}(?:뽑|기부)|혈액.{0,8}기부|헌혈)"), "헌혈 공가"),
+    (
+        re.compile(r"(?:퇴사|그만두|퇴직).{0,18}(?:정산금|돈|금액|언제)"),
+        "퇴직 퇴직금 지급 시기",
+    ),
+    (
+        re.compile(r"(?:퇴사|그만두|퇴직).{0,18}(?:나이|몇\s*살|연령)"),
+        "정년 퇴직 나이",
+    ),
+    (
+        re.compile(r"(?:마감|납품|계약).{0,30}(?:늦|지연|지체|못\s*지)"),
+        "계약 의무 지체",
+    ),
+    (
+        re.compile(
+            r"(?=.*(?:마감|납품|계약|업체|지연|지체|늦))"
+            r"(?=.*(?:페널티|패널티|벌금|위약금))"
+        ),
+        "지체상금",
+    ),
+    (
+        re.compile(
+            r"(?=.*(?:마감|납품|계약|지연|지체|늦))"
+            r"(?=.*(?:잘못|책임).{0,5}(?:없|아니))"
+        ),
+        "계약상대자 책임 없는 사유",
+    ),
+    (re.compile(r"(?:내부고발|공익제보|공익신고)"), "공익신고 공익신고자"),
+    (
+        re.compile(r"(?:정체|신분|인적사항).{0,15}(?:공개|알리|까발|누설)"),
+        "인적사항 신분 비밀보장 누설 금지",
+    ),
+    (
+        re.compile(r"(?:신고|제보).{0,18}(?:보복|불이익)"),
+        "공익신고 불이익조치 금지",
+    ),
+    (
+        re.compile(r"(?:따돌림|폭언|직장\s*내\s*괴롭힘|괴롭힘)"),
+        "직장 내 괴롭힘 신고 사건 접수 예방 대응 담당자",
+    ),
+    (re.compile(r"(?:자료|정보).{0,18}(?:보여|공개|열람)"), "정보공개 청구"),
+    (
+        re.compile(r"(?:정보|자료|공개).{0,24}(?:언제까지|기한|기간|며칠)"),
+        "공개여부 결정 통지 기간",
+    ),
+    (
+        re.compile(
+            r"(?:부모|가족|배우자).{0,24}"
+            r"(?:아프|아파|아픈|간병|돌보|보살피|보살펴)"
+        ),
+        "가족돌봄 휴직 가족돌봄 등을 위한 지원",
+    ),
+    (
+        re.compile(r"(?:정보|자료|공개).{0,20}(?:거절|비공개)"),
+        "정보공개 비공개 결정",
+    ),
+    (
+        re.compile(r"(?:거절|비공개).{0,20}(?:다시|따지|불복|이의)"),
+        "불복 이의신청",
+    ),
+    (
+        re.compile(r"(?:집에서|재택|원격).{0,15}(?:컴퓨터|일|근무)"),
+        "재택근무 원격근무 유연근무",
+    ),
+    (
+        re.compile(
+            r"(?:견적\s*없이|한\s*(?:곳|업체).{0,12}(?:맡|계약)|바로\s*맡)"
+        ),
+        "수의계약 조건",
+    ),
+)
+
+
+class SemanticUnavailable(RuntimeError):
+    """Raised when dense search cannot safely be used."""
+
+
+def runtime_paused(now: float | None = None) -> bool:
+    """Return whether an operator pause marker temporarily disables dense search.
+
+    Fly's weekly ALIO conversion runs Node/kordoc on the same 512 MB Machine.  The
+    workflow writes a marker to the persistent volume and restarts the Machine
+    first, so requests use the existing keyword fallback instead of loading ONNX
+    at the same time.  A stale marker expires automatically after two hours.
+    """
+
+    configured = os.environ.get("KOICA_SEMANTIC_PAUSE_FILE", "").strip()
+    if not configured:
+        return False
+    marker = Path(configured)
+    try:
+        modified_at = marker.stat().st_mtime
+    except FileNotFoundError:
+        return False
+    except OSError:
+        # An operator deliberately configured a marker path.  If its state cannot
+        # be inspected, fail closed to the low-memory keyword channel.
+        return True
+
+    raw_max_age = os.environ.get("KOICA_SEMANTIC_PAUSE_MAX_AGE_SEC", "")
+    try:
+        max_age = float(raw_max_age) if raw_max_age else DEFAULT_PAUSE_MAX_AGE_SEC
+    except ValueError:
+        max_age = DEFAULT_PAUSE_MAX_AGE_SEC
+    max_age = max(1.0, max_age)
+    return (time.time() if now is None else now) - modified_at <= max_age
+
+
+def expand_query(query: str) -> str:
+    """Append narrow KOICA-domain aliases for colloquial Korean expressions."""
+
+    additions: list[str] = []
+    for pattern, terms in _QUERY_ALIAS_RULES:
+        if pattern.search(query):
+            additions.append(terms)
+    if not additions:
+        return query
+    # A single query can activate complementary rules (for example late delivery,
+    # no fault, and a penalty).  Preserve rule order while removing repeats.
+    unique = list(dict.fromkeys(additions))
+    return f"{query}\n관련 규정 용어: {' '.join(unique)}"
+
+
+def default_model_dir() -> Path:
+    configured = os.environ.get("KOICA_SEMANTIC_MODEL_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    cache_home = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return cache_home / "koica-reg-mcp" / "multilingual-e5-small"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _valid_model_file(path: Path, expected_sha256: str) -> bool:
+    return path.is_file() and sha256_file(path) == expected_sha256
+
+
+def download_model(model_dir: Path | str | None = None) -> Path:
+    """Download the pinned, quantized E5 model and verify both file hashes."""
+
+    destination = Path(model_dir) if model_dir is not None else default_model_dir()
+    destination.mkdir(parents=True, exist_ok=True)
+
+    for filename, (url, expected_sha256) in MODEL_FILES.items():
+        target = destination / filename
+        if _valid_model_file(target, expected_sha256):
+            continue
+
+        temporary = target.with_name(f".{target.name}.part")
+        temporary.unlink(missing_ok=True)
+        try:
+            request = urllib.request.Request(
+                url,
+                headers={"User-Agent": "koica-reg-mcp-semantic-index/1"},
+            )
+            with urllib.request.urlopen(request, timeout=120) as response:
+                with temporary.open("wb") as output:
+                    for block in iter(lambda: response.read(1024 * 1024), b""):
+                        output.write(block)
+            actual_sha256 = sha256_file(temporary)
+            if actual_sha256 != expected_sha256:
+                raise SemanticUnavailable(
+                    f"{filename} 해시 불일치: {actual_sha256}"
+                )
+            os.replace(temporary, target)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    return destination
+
+
+def _require_model_dir(model_dir: Path | str | None = None) -> Path:
+    directory = Path(model_dir) if model_dir is not None else default_model_dir()
+    missing = [
+        filename for filename in MODEL_FILES if not (directory / filename).is_file()
+    ]
+    if missing:
+        raise SemanticUnavailable(
+            "의미 검색 모델 파일이 없습니다: " + ", ".join(missing)
+        )
+    corrupt = [
+        filename
+        for filename, (_, expected_sha256) in MODEL_FILES.items()
+        if not _valid_model_file(directory / filename, expected_sha256)
+    ]
+    if corrupt:
+        raise SemanticUnavailable(
+            "의미 검색 모델 파일의 SHA-256이 맞지 않습니다: " + ", ".join(corrupt)
+        )
+    return directory
+
+
+class DenseEncoder:
+    """Small direct ONNX wrapper for ``multilingual-e5-small``."""
+
+    def __init__(self, model_dir: Path | str | None = None) -> None:
+        try:
+            import numpy as np
+            import onnxruntime as ort
+            import sentencepiece as spm
+        except ImportError as exc:  # pragma: no cover - depends on installation
+            raise SemanticUnavailable(
+                "의미 검색 의존성(numpy, onnxruntime, sentencepiece)이 없습니다."
+            ) from exc
+
+        directory = _require_model_dir(model_dir)
+        options = ort.SessionOptions()
+        thread_count = max(1, int(os.environ.get("KOICA_SEMANTIC_THREADS", "1")))
+        options.intra_op_num_threads = thread_count
+        options.inter_op_num_threads = 1
+        options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+
+        try:
+            self._session = ort.InferenceSession(
+                str(directory / MODEL_FILENAME),
+                sess_options=options,
+                providers=["CPUExecutionProvider"],
+            )
+            self._tokenizer = spm.SentencePieceProcessor(
+                model_file=str(directory / TOKENIZER_FILENAME)
+            )
+        except Exception as exc:
+            raise SemanticUnavailable(
+                f"의미 검색 모델을 열 수 없습니다: {exc}"
+            ) from exc
+
+        self._np = np
+        self._lock = threading.Lock()
+
+    def _token_ids(self, text: str) -> list[int]:
+        # XLM-R token ids differ from raw SentencePiece ids: <s>=0, <pad>=1,
+        # </s>=2, <unk>=3, and every normal piece is shifted by one.
+        pieces = self._tokenizer.encode(text, out_type=int)[:510]
+        inner = [3 if piece == 0 else piece + 1 for piece in pieces]
+        return [0, *inner, 2]
+
+    def _embed(self, texts: Sequence[str], prefix: str) -> Any:
+        np = self._np
+        if not texts:
+            return np.empty((0, MODEL_DIMENSION), dtype=np.float32)
+
+        encoded = [self._token_ids(f"{prefix}: {text}") for text in texts]
+        width = max(len(row) for row in encoded)
+        input_ids = np.full((len(encoded), width), 1, dtype=np.int64)
+        attention_mask = np.zeros((len(encoded), width), dtype=np.int64)
+        for row_number, token_ids in enumerate(encoded):
+            input_ids[row_number, : len(token_ids)] = token_ids
+            attention_mask[row_number, : len(token_ids)] = 1
+        token_type_ids = np.zeros_like(input_ids, dtype=np.int64)
+
+        inputs: dict[str, Any] = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+        }
+        input_names = {item.name for item in self._session.get_inputs()}
+        if "token_type_ids" in input_names:
+            inputs["token_type_ids"] = token_type_ids
+
+        with self._lock:
+            hidden_state = self._session.run(None, inputs)[0]
+        mask = attention_mask[..., None].astype(np.float32)
+        pooled = (hidden_state * mask).sum(axis=1) / np.maximum(mask.sum(axis=1), 1.0)
+        norms = np.linalg.norm(pooled, axis=1, keepdims=True)
+        return (pooled / np.maximum(norms, 1e-12)).astype(np.float32)
+
+    def embed_queries(self, texts: Sequence[str]) -> Any:
+        return self._embed(texts, "query")
+
+    def embed_passages(self, texts: Sequence[str]) -> Any:
+        return self._embed(texts, "passage")
+
+
+_ENCODER: DenseEncoder | None = None
+_ENCODER_KEY: str | None = None
+_ENCODER_LOCK = threading.Lock()
+
+
+def get_encoder(model_dir: Path | str | None = None) -> DenseEncoder:
+    global _ENCODER, _ENCODER_KEY
+    key = (
+        str(Path(model_dir).resolve())
+        if model_dir is not None
+        else str(default_model_dir())
+    )
+    with _ENCODER_LOCK:
+        if _ENCODER is None or _ENCODER_KEY != key:
+            _ENCODER = DenseEncoder(model_dir)
+            _ENCODER_KEY = key
+        return _ENCODER
+
+
+def iter_text_chunks(
+    text: str,
+    chunk_size: int = CHUNK_SIZE,
+    overlap: int = CHUNK_OVERLAP,
+) -> Iterable[tuple[int, int, str]]:
+    """Yield deterministic overlapping character chunks, including the tail."""
+
+    if chunk_size <= 0 or overlap < 0 or overlap >= chunk_size:
+        raise ValueError(
+            "chunk_size는 양수이고 overlap은 0 이상 chunk_size 미만이어야 합니다."
+        )
+    body = text or ""
+    if not body:
+        yield 0, 0, ""
+        return
+
+    start = 0
+    while start < len(body):
+        end = min(start + chunk_size, len(body))
+        yield start, end, body[start:end]
+        if end == len(body):
+            break
+        start = end - overlap
+
+
+@dataclass(frozen=True)
+class _Chunk:
+    kind: str
+    item_index: int
+    start: int
+    end: int
+    text: str
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "item_index": self.item_index,
+            "start": self.start,
+            "end": self.end,
+        }
+
+
+def _article_header(article: Any) -> str:
+    fields = [
+        getattr(article, "source", ""),
+        getattr(article, "chapter", ""),
+        getattr(article, "article", ""),
+        getattr(article, "article_title", ""),
+    ]
+    return " · ".join(str(value) for value in fields if value)
+
+
+def _attachment_header(attachment: Any) -> str:
+    fields = [
+        getattr(attachment, "source", ""),
+        getattr(attachment, "kind", ""),
+        getattr(attachment, "label", ""),
+        getattr(attachment, "title", ""),
+    ]
+    return " · ".join(str(value) for value in fields if value)
+
+
+def make_chunks(articles: Sequence[Any], attachments: Sequence[Any]) -> list[_Chunk]:
+    chunks: list[_Chunk] = []
+    for item_index, article in enumerate(articles):
+        header = _article_header(article)
+        for start, end, body in iter_text_chunks(getattr(article, "body", "")):
+            chunks.append(_Chunk("article", item_index, start, end, f"{header}\n{body}"))
+
+    for item_index, attachment in enumerate(attachments):
+        if getattr(attachment, "deleted", False):
+            continue
+        header = _attachment_header(attachment)
+        for start, end, body in iter_text_chunks(getattr(attachment, "body", "")):
+            chunks.append(_Chunk("attachment", item_index, start, end, f"{header}\n{body}"))
+    return chunks
+
+
+def invalidate_artifacts(
+    vectors_path: Path | str = DEFAULT_VECTORS_PATH,
+    meta_path: Path | str = DEFAULT_META_PATH,
+) -> None:
+    Path(meta_path).unlink(missing_ok=True)
+    Path(vectors_path).unlink(missing_ok=True)
+    reset_caches()
+
+
+def build_semantic_index(
+    articles: Sequence[Any],
+    attachments: Sequence[Any],
+    *,
+    index_path: Path | str = DEFAULT_INDEX_PATH,
+    vectors_path: Path | str = DEFAULT_VECTORS_PATH,
+    meta_path: Path | str = DEFAULT_META_PATH,
+    model_dir: Path | str | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    download: bool = True,
+) -> dict[str, Any]:
+    """Encode every searchable chunk and atomically replace dense artifacts."""
+
+    try:
+        import numpy as np
+    except ImportError as exc:  # pragma: no cover - depends on installation
+        raise SemanticUnavailable("의미 검색 의존성 numpy가 없습니다.") from exc
+
+    index_file = Path(index_path)
+    vectors_file = Path(vectors_path)
+    meta_file = Path(meta_path)
+    if not index_file.is_file():
+        raise SemanticUnavailable(f"키워드 인덱스가 없습니다: {index_file}")
+    if batch_size <= 0:
+        raise ValueError("batch_size는 양수여야 합니다.")
+
+    if download:
+        directory = download_model(model_dir)
+    else:
+        directory = _require_model_dir(model_dir)
+    encoder = get_encoder(directory)
+    chunks = make_chunks(articles, attachments)
+    if not chunks:
+        raise SemanticUnavailable("임베딩할 검색 문서가 없습니다.")
+
+    vectors_file.parent.mkdir(parents=True, exist_ok=True)
+    meta_file.parent.mkdir(parents=True, exist_ok=True)
+    temporary_vectors = vectors_file.with_name(f".{vectors_file.name}.tmp")
+    temporary_meta = meta_file.with_name(f".{meta_file.name}.tmp")
+    temporary_vectors.unlink(missing_ok=True)
+    temporary_meta.unlink(missing_ok=True)
+
+    try:
+        vectors = np.lib.format.open_memmap(
+            temporary_vectors,
+            mode="w+",
+            dtype=np.float32,
+            shape=(len(chunks), MODEL_DIMENSION),
+        )
+        for start in range(0, len(chunks), batch_size):
+            batch = chunks[start : start + batch_size]
+            vectors[start : start + len(batch)] = encoder.embed_passages(
+                [chunk.text for chunk in batch]
+            )
+            completed = start + len(batch)
+            if completed == len(chunks) or completed % 512 < batch_size:
+                print(
+                    f"의미 인덱스 임베딩: {completed}/{len(chunks)} 청크",
+                    file=sys.stderr,
+                    flush=True,
+                )
+        vectors.flush()
+        del vectors
+
+        metadata: dict[str, Any] = {
+            "schema_version": SEMANTIC_SCHEMA_VERSION,
+            "model": MODEL_NAME,
+            "model_revision": MODEL_REVISION,
+            "dimension": MODEL_DIMENSION,
+            "chunk_size": CHUNK_SIZE,
+            "chunk_overlap": CHUNK_OVERLAP,
+            "index_sha256": sha256_file(index_file),
+            "vector_count": len(chunks),
+            "chunks": [chunk.metadata() for chunk in chunks],
+        }
+        temporary_meta.write_text(
+            json.dumps(metadata, ensure_ascii=False, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        os.replace(temporary_vectors, vectors_file)
+        os.replace(temporary_meta, meta_file)
+        reset_caches()
+        return metadata
+    except Exception:
+        temporary_vectors.unlink(missing_ok=True)
+        temporary_meta.unlink(missing_ok=True)
+        # Never leave old dense data looking current after the lexical index changed.
+        meta_file.unlink(missing_ok=True)
+        reset_caches()
+        raise
+
+
+class SemanticIndex:
+    def __init__(
+        self,
+        *,
+        index_path: Path | str = DEFAULT_INDEX_PATH,
+        vectors_path: Path | str = DEFAULT_VECTORS_PATH,
+        meta_path: Path | str = DEFAULT_META_PATH,
+    ) -> None:
+        try:
+            import numpy as np
+        except ImportError as exc:  # pragma: no cover - depends on installation
+            raise SemanticUnavailable("의미 검색 의존성 numpy가 없습니다.") from exc
+
+        self._np = np
+        index_file = Path(index_path)
+        vectors_file = Path(vectors_path)
+        meta_file = Path(meta_path)
+        if not vectors_file.is_file() or not meta_file.is_file():
+            raise SemanticUnavailable("의미 검색 인덱스가 아직 생성되지 않았습니다.")
+
+        try:
+            metadata = json.loads(meta_file.read_text(encoding="utf-8"))
+            if metadata.get("schema_version") != SEMANTIC_SCHEMA_VERSION:
+                raise ValueError("지원하지 않는 스키마")
+            if metadata.get("model_revision") != MODEL_REVISION:
+                raise ValueError("모델 리비전 불일치")
+            if metadata.get("index_sha256") != sha256_file(index_file):
+                raise ValueError("키워드 인덱스와 의미 인덱스가 서로 다름")
+
+            chunks = metadata["chunks"]
+            vectors = np.load(vectors_file, mmap_mode="r")
+            expected_shape = (len(chunks), MODEL_DIMENSION)
+            if (
+                vectors.shape != expected_shape
+                or metadata.get("vector_count") != len(chunks)
+            ):
+                raise ValueError("벡터와 메타데이터 개수 불일치")
+
+            self.vectors = vectors
+            self.kinds = np.asarray([row["kind"] for row in chunks])
+            self.item_indices = np.asarray(
+                [int(row["item_index"]) for row in chunks], dtype=np.int32
+            )
+            self.starts = np.asarray(
+                [int(row["start"]) for row in chunks], dtype=np.int32
+            )
+            self.ends = np.asarray([int(row["end"]) for row in chunks], dtype=np.int32)
+            if not np.isin(self.kinds, ("article", "attachment")).all():
+                raise ValueError("알 수 없는 청크 종류")
+            if self.item_indices.size and int(self.item_indices.min()) < 0:
+                raise ValueError("음수 문서 인덱스")
+        except SemanticUnavailable:
+            raise
+        except Exception as exc:
+            raise SemanticUnavailable(
+                f"의미 검색 인덱스가 유효하지 않습니다: {exc}"
+            ) from exc
+
+    def rank(
+        self,
+        query_vector: Any,
+        *,
+        article_allowed: Sequence[bool],
+        attachment_allowed: Sequence[bool],
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        np = self._np
+        if limit <= 0:
+            return []
+
+        article_mask = np.asarray(article_allowed, dtype=bool)
+        attachment_mask = np.asarray(attachment_allowed, dtype=bool)
+        valid = np.zeros(len(self.item_indices), dtype=bool)
+        article_rows = self.kinds == "article"
+        attachment_rows = self.kinds == "attachment"
+
+        article_ids = self.item_indices[article_rows]
+        attachment_ids = self.item_indices[attachment_rows]
+        if article_ids.size and int(article_ids.max()) >= len(article_mask):
+            raise SemanticUnavailable(
+                "의미 검색 조문 매핑이 현재 데이터와 맞지 않습니다."
+            )
+        if attachment_ids.size and int(attachment_ids.max()) >= len(attachment_mask):
+            raise SemanticUnavailable(
+                "의미 검색 별표 매핑이 현재 데이터와 맞지 않습니다."
+            )
+        valid[article_rows] = article_mask[article_ids]
+        valid[attachment_rows] = attachment_mask[attachment_ids]
+        valid_rows = np.flatnonzero(valid)
+        if not valid_rows.size:
+            return []
+
+        scores = np.asarray(self.vectors @ query_vector, dtype=np.float32)
+        order = valid_rows[np.argsort(-scores[valid_rows], kind="stable")]
+        results: list[dict[str, Any]] = []
+        seen: set[tuple[str, int]] = set()
+        for row in order:
+            kind = str(self.kinds[row])
+            item_index = int(self.item_indices[row])
+            key = (kind, item_index)
+            if key in seen:
+                continue
+            seen.add(key)
+            results.append(
+                {
+                    "kind": kind,
+                    "item_index": item_index,
+                    "score": float(scores[row]),
+                    "start": int(self.starts[row]),
+                    "end": int(self.ends[row]),
+                }
+            )
+            if len(results) >= limit:
+                break
+        return results
+
+
+_SEMANTIC_INDEX: SemanticIndex | None = None
+_SEMANTIC_INDEX_KEY: tuple[str, str, str] | None = None
+_INDEX_LOCK = threading.Lock()
+_SEARCH_LOCK = threading.Lock()
+
+
+def get_semantic_index(
+    *,
+    index_path: Path | str = DEFAULT_INDEX_PATH,
+    vectors_path: Path | str = DEFAULT_VECTORS_PATH,
+    meta_path: Path | str = DEFAULT_META_PATH,
+) -> SemanticIndex:
+    global _SEMANTIC_INDEX, _SEMANTIC_INDEX_KEY
+    key = (str(Path(index_path)), str(Path(vectors_path)), str(Path(meta_path)))
+    with _INDEX_LOCK:
+        if _SEMANTIC_INDEX is None or _SEMANTIC_INDEX_KEY != key:
+            _SEMANTIC_INDEX = SemanticIndex(
+                index_path=index_path,
+                vectors_path=vectors_path,
+                meta_path=meta_path,
+            )
+            _SEMANTIC_INDEX_KEY = key
+        return _SEMANTIC_INDEX
+
+
+def semantic_rank(
+    query: str,
+    *,
+    article_allowed: Sequence[bool],
+    attachment_allowed: Sequence[bool],
+    limit: int = 50,
+    index_path: Path | str = DEFAULT_INDEX_PATH,
+    vectors_path: Path | str = DEFAULT_VECTORS_PATH,
+    meta_path: Path | str = DEFAULT_META_PATH,
+    model_dir: Path | str | None = None,
+) -> list[dict[str, Any]]:
+    if not query.strip() or limit <= 0:
+        return []
+    if runtime_paused():
+        raise SemanticUnavailable(
+            "운영 데이터 동기화 중이라 의미 검색을 잠시 쉬고 있습니다."
+        )
+    # The deployed Fly machine has 512MB RAM.  Serialize the complete dense path so
+    # a future MCP/threadpool change cannot overlap ONNX workspaces and matrix reads.
+    with _SEARCH_LOCK:
+        # Also check under the search lock so a marker created while another dense
+        # request was finishing cannot be missed by the next request.
+        if runtime_paused():
+            raise SemanticUnavailable(
+                "운영 데이터 동기화 중이라 의미 검색을 잠시 쉬고 있습니다."
+            )
+        encoder = get_encoder(model_dir)
+        dense_index = get_semantic_index(
+            index_path=index_path,
+            vectors_path=vectors_path,
+            meta_path=meta_path,
+        )
+        query_vector = encoder.embed_queries([expand_query(query)])[0]
+        return dense_index.rank(
+            query_vector,
+            article_allowed=article_allowed,
+            attachment_allowed=attachment_allowed,
+            limit=limit,
+        )
+
+
+def reset_caches() -> None:
+    global _ENCODER, _ENCODER_KEY, _SEMANTIC_INDEX, _SEMANTIC_INDEX_KEY
+    with _ENCODER_LOCK:
+        _ENCODER = None
+        _ENCODER_KEY = None
+    with _INDEX_LOCK:
+        _SEMANTIC_INDEX = None
+        _SEMANTIC_INDEX_KEY = None
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(description="KOICA 규정 의미 검색 모델 관리")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    download_parser = subparsers.add_parser(
+        "download-model", help="고정 버전 E5 모델 다운로드"
+    )
+    download_parser.add_argument("--model-dir", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.command == "download-model":
+        destination = download_model(args.model_dir)
+        print(f"의미 검색 모델 준비 완료: {destination}")
+
+
+if __name__ == "__main__":
+    _main()

--- a/tests/evaluate_semantic_quality.py
+++ b/tests/evaluate_semantic_quality.py
@@ -1,0 +1,102 @@
+"""Small end-to-end Korean paraphrase gate for the built semantic index.
+
+This is intentionally not named ``test_*.py``: normal unit tests remain model-free.
+Docker/CI runs this script only after ``build --strict-semantic`` has produced the
+real corpus vectors.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import koica_search as ks  # noqa: E402
+
+
+CASES = (
+    ("아이 때문에 몇 달 회사를 쉬고 싶다", "인사규정 제45조의3"),
+    ("주말은 쉬는 날인가", "복무규정 제22조"),
+    ("피를 뽑아 기부하러 갈 때 근무로 인정되나", "복무규정 제26조"),
+    ("퇴사 후 정산금은 언제 들어오나", "퇴직금규정 제9조"),
+    (
+        "마감 못 지킨 업체에게 페널티를 물릴 수 있나",
+        "대외무상협력사업에 관한 조달 및 계약규정 제30조",
+    ),
+    (
+        "내부고발자 정체를 동료에게 까발려도 되나",
+        "공익신고 처리 및 신고자 보호 등에 관한 운영지침 제23조",
+    ),
+    (
+        "신고했다고 인사상 보복해도 되나",
+        "공익신고 처리 및 신고자 보호 등에 관한 운영지침 제24조",
+    ),
+    (
+        "상사에게 따돌림과 폭언을 당했는데 누구한테 얘기하나",
+        "직장 내 괴롭힘 방지 및 예방 지침 제10조",
+    ),
+    (
+        "기관 자료 보여달라 했는데 언제까지 알려줘야 하나",
+        "정보공개 운영규정 제12조",
+    ),
+    (
+        "부모님이 아파서 오래 보살펴야 하는데 일을 쉴 수 있나",
+        "인사규정 제45조의2",
+    ),
+    ("회사를 그만두게 되는 나이는 몇 살인가", "인사규정 제50조"),
+    (
+        "자료 공개를 거절당했는데 다시 따질 수 있나",
+        "정보공개 운영규정 제15조",
+    ),
+    ("집에서 컴퓨터로 일하는 제도가 있나", "유연근무제 운영지침 제4조"),
+    (
+        "여러 업체 견적 없이 한 곳에 바로 맡길 수 있는 조건",
+        "대외무상협력사업에 관한 조달 및 계약규정 제23조의2",
+    ),
+    (
+        "잘못 없이 납품이 늦어져도 벌금을 내나",
+        "대외무상협력사업에 관한 조달 및 계약규정 제30조",
+    ),
+)
+
+
+def recall_at_10(mode: str) -> tuple[int, list[str]]:
+    hits = 0
+    misses: list[str] = []
+    for query, expected_citation in CASES:
+        citations = {
+            row["citation"] for row in ks.search(query, limit=10, mode=mode)
+        }
+        if expected_citation in citations:
+            hits += 1
+        else:
+            misses.append(f"{query} → {expected_citation}")
+    return hits, misses
+
+
+def main() -> None:
+    keyword_hits, _ = recall_at_10("keyword")
+    hybrid_hits, hybrid_misses = recall_at_10("hybrid")
+    total = len(CASES)
+    print(
+        f"한국어 의역 Recall@10: keyword={keyword_hits}/{total}, "
+        f"hybrid={hybrid_hits}/{total}"
+    )
+    for miss in hybrid_misses:
+        print(f"MISS: {miss}")
+
+    minimum_hits = 12  # 80% of the fixed 15-query paraphrase set
+    minimum_gain = 6
+    if hybrid_hits < minimum_hits:
+        raise SystemExit(f"hybrid Recall@10 미달: {hybrid_hits} < {minimum_hits}")
+    if hybrid_hits - keyword_hits < minimum_gain:
+        raise SystemExit(
+            f"keyword 대비 hybrid 개선폭 미달: {hybrid_hits - keyword_hits} < {minimum_gain}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -1,0 +1,418 @@
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+import koica_search as ks
+import semantic_search
+
+
+def make_article(
+    *,
+    source: str = "인사규정",
+    category: str = "규정",
+    article_no: int = 1,
+    article_sub: int = 0,
+    title: str = "테스트",
+    body: str = "테스트 본문",
+) -> ks.Article:
+    article = f"제{article_no}조" + (f"의{article_sub}" if article_sub else "")
+    return ks.Article(
+        category=category,
+        source=source,
+        revision="2026.08.02.",
+        file="data/extracted/test.md",
+        chapter="제1장 테스트",
+        article=article,
+        article_no=article_no,
+        article_sub=article_sub,
+        article_title=title,
+        body=body,
+    )
+
+
+def make_attachment(
+    *,
+    source: str = "인사규정",
+    category: str = "규정",
+    number: str = "1",
+    title: str = "테스트 서식",
+    body: str = "테스트 별지 본문",
+    deleted: bool = False,
+) -> ks.Attachment:
+    return ks.Attachment(
+        category=category,
+        source=source,
+        revision="2026.08.02.",
+        file="data/extracted/test.md",
+        kind="별지",
+        label=f"[별지 {number}]",
+        number=number,
+        title=title,
+        body=body,
+        deleted=deleted,
+    )
+
+
+class ReciprocalRankFusionTests(unittest.TestCase):
+    def test_default_fusion_keeps_both_single_channel_candidates(self):
+        keyword_only = ("article", 0)
+        semantic_only = ("article", 1)
+
+        fused = ks._rrf_fuse([keyword_only], [semantic_only])
+
+        self.assertEqual({key for key, _score in fused}, {keyword_only, semantic_only})
+        self.assertEqual(fused[0][1], fused[1][1])
+
+    def test_equal_weights_are_symmetric_and_cross_channel_hits_are_deduplicated(self):
+        first = ("article", 0)
+        second = ("article", 1)
+
+        fused = ks._rrf_fuse(
+            [first, second],
+            [second, first],
+            k=60,
+            semantic_weight=1.0,
+        )
+
+        self.assertEqual([key for key, _score in fused], [first, second])
+        self.assertEqual(len(fused), 2)
+        expected = (1.0 / 61.0) + (1.0 / 62.0)
+        self.assertAlmostEqual(fused[0][1], expected)
+        self.assertAlmostEqual(fused[1][1], expected)
+
+    def test_candidate_found_by_both_channels_is_returned_once_with_both_scores(self):
+        shared = ("article", 0)
+        keyword_only = ("article", 1)
+
+        fused = ks._rrf_fuse(
+            [shared, keyword_only],
+            [shared],
+            k=60,
+            semantic_weight=1.0,
+        )
+
+        self.assertEqual([key for key, _score in fused].count(shared), 1)
+        self.assertEqual(fused[0][0], shared)
+        self.assertAlmostEqual(fused[0][1], 2.0 / 61.0)
+
+    def test_both_channel_heads_are_preserved_when_consensus_hits_fill_window(self):
+        keyword_head = ("article", 0)
+        semantic_head = ("article", 1)
+        shared = [("article", index) for index in range(2, 11)]
+        keyword_keys = [keyword_head, *shared]
+        semantic_keys = [semantic_head, *shared]
+        fused = ks._rrf_fuse(keyword_keys, semantic_keys)
+
+        selected = ks._preserve_channel_heads(
+            fused,
+            keyword_keys,
+            semantic_keys,
+            limit=10,
+        )
+
+        self.assertEqual(len(selected), 10)
+        self.assertIn(keyword_head, [key for key, _score in selected])
+        self.assertIn(semantic_head, [key for key, _score in selected])
+
+
+class HybridSearchContractTests(unittest.TestCase):
+    def test_legacy_positional_call_falls_back_to_the_keyword_ranking(self):
+        article = make_article(
+            article_no=45,
+            article_sub=3,
+            title="육아휴직",
+            body="직원이 육아휴직을 신청하는 경우 이를 허용하여야 한다.",
+        )
+
+        with (
+            patch.object(ks, "load_index", return_value=[article]),
+            patch.object(ks, "load_attachments", return_value=[]),
+            patch.object(
+                semantic_search,
+                "semantic_rank",
+                side_effect=semantic_search.SemanticUnavailable("offline"),
+            ) as semantic_rank,
+            patch.object(ks, "_SEMANTIC_WARNING_EMITTED", False),
+            patch("sys.stderr", new=io.StringIO()),
+        ):
+            # Six positional arguments were the complete public signature before
+            # hybrid search was added.  They must retain their original meaning.
+            fallback = ks.search("육아휴직", None, None, 1, False, False)
+            keyword = ks.search(
+                "육아휴직", None, None, 1, False, False, mode="keyword"
+            )
+
+        semantic_rank.assert_called_once()
+        self.assertEqual(fallback[0]["citation"], keyword[0]["citation"])
+        self.assertEqual(fallback[0]["keyword_score"], keyword[0]["keyword_score"])
+        self.assertEqual(fallback[0]["search_mode"], "keyword_fallback")
+        self.assertEqual(fallback[0]["matched_by"], "keyword")
+        self.assertIsNone(fallback[0]["semantic_score"])
+
+    def test_keyword_mode_never_calls_the_semantic_backend(self):
+        article = make_article(title="육아휴직", body="육아휴직 신청 절차")
+        with (
+            patch.object(ks, "load_index", return_value=[article]),
+            patch.object(ks, "load_attachments", return_value=[]),
+            patch.object(semantic_search, "semantic_rank") as semantic_rank,
+        ):
+            results = ks.search("육아휴직", mode="keyword")
+
+        semantic_rank.assert_not_called()
+        self.assertEqual(results[0]["search_mode"], "keyword")
+
+    def test_semantic_mode_skips_keyword_tokenization_and_corpus_scan(self):
+        article = make_article(title="육아휴직", body="육아휴직 신청 절차")
+        with (
+            patch.object(ks, "load_index", return_value=[article]),
+            patch.object(ks, "load_attachments", return_value=[]),
+            patch.object(ks, "tokenize", side_effect=AssertionError("keyword scan")),
+            patch.object(semantic_search, "semantic_rank", return_value=[]),
+        ):
+            results = ks.search("아이를 돌보려고 쉰다", mode="semantic")
+
+        self.assertEqual(results, [])
+
+    def test_semantic_only_candidate_handles_wording_mismatch(self):
+        target = make_article(
+            article_no=45,
+            article_sub=3,
+            title="육아휴직",
+            body="만 8세 이하의 자녀를 양육하기 위한 휴직을 허용한다.",
+        )
+        query = "아이를 돌보느라 잠시 쉬고 싶다"
+        self.assertEqual(ks.score_article(target, ks.tokenize(query))[0], 0.0)
+
+        dense_hit = {
+            "kind": "article",
+            "item_index": 0,
+            "score": 0.91,
+            "start": 0,
+            "end": len(target.body),
+        }
+        with (
+            patch.object(ks, "load_index", return_value=[target]),
+            patch.object(ks, "load_attachments", return_value=[]),
+            patch.object(
+                semantic_search, "semantic_rank", return_value=[dense_hit]
+            ) as semantic_rank,
+        ):
+            results = ks.search(query, mode="hybrid")
+
+        semantic_rank.assert_called_once()
+        self.assertEqual(results[0]["citation"], "인사규정 제45조의3")
+        self.assertEqual(results[0]["matched_by"], "semantic")
+        self.assertIsNone(results[0]["keyword_score"])
+        self.assertEqual(results[0]["semantic_score"], 0.91)
+
+    def test_category_source_and_attachment_filters_are_passed_to_semantic_rank(self):
+        articles = [
+            make_article(source="인사규정", category="규정", article_no=1),
+            make_article(source="복무규정", category="규정", article_no=2),
+            make_article(source="인사관리지침", category="지침", article_no=3),
+        ]
+        attachments = [
+            make_attachment(source="인사규정", category="규정", number="1"),
+            make_attachment(source="복무규정", category="규정", number="2"),
+            make_attachment(
+                source="인사규정", category="규정", number="3", deleted=True
+            ),
+        ]
+
+        with (
+            patch.object(ks, "load_index", return_value=articles),
+            patch.object(ks, "load_attachments", return_value=attachments),
+            patch.object(
+                semantic_search, "semantic_rank", return_value=[]
+            ) as semantic_rank,
+        ):
+            ks.search(
+                "휴직 문의",
+                category="규정",
+                source="인사",
+                include_attachments=True,
+                mode="semantic",
+            )
+
+        call = semantic_rank.call_args.kwargs
+        self.assertEqual(call["article_allowed"], [True, False, False])
+        self.assertEqual(call["attachment_allowed"], [True, False, False])
+
+        with (
+            patch.object(ks, "load_index", return_value=articles),
+            patch.object(ks, "load_attachments", return_value=attachments),
+            patch.object(
+                semantic_search, "semantic_rank", return_value=[]
+            ) as semantic_rank,
+        ):
+            ks.search(
+                "휴직 문의",
+                category="규정",
+                source="인사",
+                include_attachments=False,
+                mode="semantic",
+            )
+
+        self.assertEqual(
+            semantic_rank.call_args.kwargs["attachment_allowed"],
+            [False, False, False],
+        )
+
+    def test_stopword_only_query_still_reaches_semantic_search(self):
+        article = make_article(title="휴직", body="자녀 양육을 위한 휴직")
+        query = "다음 중 옳은 것은"
+        self.assertEqual(ks.tokenize(query), [])
+        dense_hit = {
+            "kind": "article",
+            "item_index": 0,
+            "score": 0.72,
+            "start": 0,
+            "end": len(article.body),
+        }
+
+        with (
+            patch.object(ks, "load_index", return_value=[article]),
+            patch.object(ks, "load_attachments", return_value=[]),
+            patch.object(
+                semantic_search, "semantic_rank", return_value=[dense_hit]
+            ) as semantic_rank,
+        ):
+            results = ks.search(query, mode="hybrid")
+
+        semantic_rank.assert_called_once()
+        self.assertEqual(semantic_rank.call_args.args[0], query)
+        self.assertEqual(results[0]["matched_by"], "semantic")
+
+    def test_invalid_mode_is_rejected_before_loading_the_corpus(self):
+        with patch.object(ks, "load_index") as load_index:
+            with self.assertRaisesRegex(ValueError, "mode는 다음 중 하나"):
+                ks.search("육아휴직", mode="vector")
+
+        load_index.assert_not_called()
+
+
+class SemanticArtifactTests(unittest.TestCase):
+    def test_recent_operator_marker_pauses_dense_search_and_stale_one_expires(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            marker = Path(tmp) / "semantic-search.paused"
+            marker.touch()
+            modified_at = marker.stat().st_mtime
+            env = {
+                "KOICA_SEMANTIC_PAUSE_FILE": str(marker),
+                "KOICA_SEMANTIC_PAUSE_MAX_AGE_SEC": "60",
+            }
+
+            with patch.dict(os.environ, env, clear=False):
+                self.assertTrue(semantic_search.runtime_paused(now=modified_at + 30))
+                self.assertFalse(
+                    semantic_search.runtime_paused(now=modified_at + 61)
+                )
+
+    def test_pause_marker_rejects_dense_search_before_model_loading(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            marker = Path(tmp) / "semantic-search.paused"
+            marker.touch()
+            with (
+                patch.dict(
+                    os.environ,
+                    {"KOICA_SEMANTIC_PAUSE_FILE": str(marker)},
+                    clear=False,
+                ),
+                patch.object(semantic_search, "get_encoder") as get_encoder,
+            ):
+                with self.assertRaisesRegex(
+                    semantic_search.SemanticUnavailable, "동기화 중"
+                ):
+                    semantic_search.semantic_rank(
+                        "육아휴직",
+                        article_allowed=[],
+                        attachment_allowed=[],
+                    )
+
+            get_encoder.assert_not_called()
+
+    def test_colloquial_query_aliases_do_not_change_unrelated_queries(self):
+        expanded = semantic_search.expand_query(
+            "잘못 없이 납품이 늦어져도 벌금을 내나"
+        )
+
+        self.assertIn("책임 없는 사유", expanded)
+        self.assertIn("계약 의무 지체", expanded)
+        self.assertIn("지체상금", expanded)
+        self.assertEqual(
+            semantic_search.expand_query("인사위원회 구성"),
+            "인사위원회 구성",
+        )
+        self.assertEqual(
+            semantic_search.expand_query("규정을 위반하면 벌금을 내나"),
+            "규정을 위반하면 벌금을 내나",
+        )
+
+    def test_character_chunks_overlap_and_include_the_tail(self):
+        text = "0123456789XYZ"
+
+        chunks = list(
+            semantic_search.iter_text_chunks(text, chunk_size=6, overlap=2)
+        )
+
+        self.assertEqual(
+            chunks,
+            [
+                (0, 6, "012345"),
+                (4, 10, "456789"),
+                (8, 13, "89XYZ"),
+            ],
+        )
+        self.assertEqual(chunks[-1][1], len(text))
+        self.assertEqual(chunks[-2][2][-2:], chunks[-1][2][:2])
+
+    def test_stale_keyword_index_fingerprint_rejects_semantic_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            index_path = root / "index.json"
+            vectors_path = root / "semantic_vectors.npy"
+            meta_path = root / "semantic_meta.json"
+            index_path.write_text('{"version":2,"articles":[]}', encoding="utf-8")
+            np.save(
+                vectors_path,
+                np.zeros((1, semantic_search.MODEL_DIMENSION), dtype=np.float32),
+            )
+            meta_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": semantic_search.SEMANTIC_SCHEMA_VERSION,
+                        "model_revision": semantic_search.MODEL_REVISION,
+                        "index_sha256": "stale-fingerprint",
+                        "vector_count": 1,
+                        "chunks": [
+                            {
+                                "kind": "article",
+                                "item_index": 0,
+                                "start": 0,
+                                "end": 1,
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                semantic_search.SemanticUnavailable,
+                "키워드 인덱스와 의미 인덱스가 서로 다름",
+            ):
+                semantic_search.SemanticIndex(
+                    index_path=index_path,
+                    vectors_path=vectors_path,
+                    meta_path=meta_path,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add local ONNX multilingual-E5 semantic indexing and retrieval
- make `hybrid` the default search mode while retaining `keyword` and `semantic` modes
- fuse keyword and semantic rankings with equal-weight RRF and preserve each channel's first hit
- validate model files, corpus fingerprints, and vector metadata; fall back to keyword search when dense search is unavailable
- wire strict semantic builds and Korean paraphrase quality gates into Docker and ALIO sync CI
- pause dense retrieval during the 512 MB Fly Machine's weekly HWP conversion to avoid memory contention
- update MCP schemas, dependencies, documentation, counts, licensing, and RAG-layer explanation

## Why

The previous keyword/IDF search could miss relevant articles when a user's wording differed from the formal regulation terminology. The MCP server also needed accurate documentation of its current tool count, corpus size, and role as the retrieval layer rather than an answer-generating RAG application.

## Impact

Natural-language paraphrases now retrieve relevant provisions without sending queries to an external embedding API. Exact keyword results remain protected, and hybrid requests degrade safely to the existing keyword ranking when semantic artifacts or runtime resources are unavailable.

## Validation

- 26 unit tests
- full-corpus Korean paraphrase Recall@10: keyword 0/15, hybrid 15/15
- Python compile checks
- remote MCP tool count and search-mode schema validation
- GitHub Actions YAML and Fly TOML parsing
- `git diff --check`
