### PR TITLE
docs: AGENTS·CLAUDE 문서의 도구 프레이밍을 README와 정렬

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,9 @@ claude mcp add --transport http koica-reg https://koica-reg-mcp.fly.dev/mcp
 `find_references`, `compliance_radar`, `list_attachments`, `get_attachment`,
 `list_sources`. 공개 서버라 토큰·헤더가 필요 없습니다.
 
+데이터는 ALIO 주간 자동 동기화로 서버가 최신을 유지합니다 — 커넥터 사용자가
+실행할 동기화·업데이트 명령은 없습니다.
+
 ---
 
 ## 🛠️ 이 저장소를 "개발·수정·기여"하려는 경우에만 clone
@@ -46,8 +49,8 @@ python3 semantic_search.py download-model
 python3 koica_search.py build --strict-semantic
 ```
 
-- `koica_mcp_server.py` — 로컬 stdio 서버 (도구 11개 = 원격 8개 + `update`·`sync_from_alio`·`find_questions`)
-- `server_http.py` — 원격 HTTP(streamable-http) 서버 (읽기 8개)
+- `koica_mcp_server.py` — 로컬 stdio 서버 (도구 11개 = 원격 8개 + 관리·개발용 3개: `update`·`sync_from_alio`·`find_questions`)
+- `server_http.py` — 원격 HTTP(streamable-http) 서버 (위 8개 그대로. 상태를 바꾸는 도구는 노출하지 않음)
 - `Dockerfile` + `fly.toml` — Fly.io 배포. **`main`에 머지되면 GitHub Actions가 자동 재배포**합니다.
 - 검색 엔진은 기존 IDF 키워드 점수와 로컬 `intfloat/multilingual-e5-small` ONNX 의미 유사도를 결합합니다. 외부 임베딩 API나 API 키는 쓰지 않습니다.
 - 의미 모델은 고정 리비전·SHA-256을 검증해 사용자 캐시에 받고, `numpy`·`onnxruntime`·`sentencepiece`로 추론합니다. 배포 경로는 `KOICA_SEMANTIC_MODEL_DIR`로 고정할 수 있습니다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ claude mcp add --transport http koica-reg https://koica-reg-mcp.fly.dev/mcp
 등록·재시작 후 KOICA 규정을 자연어로 물으면 `koica-reg` 도구(8종)가 자동 호출됩니다.
 예: "KOICA 승진 가점 규정 찾아줘", "인사규정 제11조 보여줘".
 공개 서버라 인증·토큰이 필요 없습니다.
+데이터는 ALIO 주간 자동 동기화로 서버가 최신을 유지합니다 — 커넥터 사용자가 실행할 명령은 없습니다.
 
 다른 클라이언트:
 - **Codex**: `codex mcp add koica-reg --url https://koica-reg-mcp.fly.dev/mcp`
@@ -21,7 +22,8 @@ claude mcp add --transport http koica-reg https://koica-reg-mcp.fly.dev/mcp
 ## 🛠️ 개발·수정하려는 경우에만 clone
 
 상세는 [AGENTS.md](AGENTS.md)와 [README](README.md) 참고.
-- 로컬 stdio: `koica_mcp_server.py`(도구 11개) / 원격 HTTP: `server_http.py`(읽기 8개)
+- 원격 HTTP: `server_http.py` — 규정 검색·조회·검증에 필요한 8개
+- 로컬 stdio: `koica_mcp_server.py` — 도구 11개 = 원격 8개 + 관리·개발용 3개(`update`·`sync_from_alio`·`find_questions`)
 - 배포: `Dockerfile`+`fly.toml`(Fly.io). `main` 머지 시 자동 재배포.
 - 검색 엔진은 IDF 키워드 + 로컬 `intfloat/multilingual-e5-small` ONNX 의미 검색을 결합합니다. 외부 임베딩 API는 사용하지 않습니다.
 - 로컬 빌드: `pip install -r requirements.txt` → `python3 semantic_search.py download-model` → `python3 koica_search.py build --strict-semantic`.


### PR DESCRIPTION
#26의 후속. README를 원격 커넥터 우선 구조로 정리했지만, 에이전트 안내 문서 두 곳에 같은 프레이밍 문제가 남아 있었다.

## 점검 결과

세 기준(도구 개수 프레이밍 / 최신화 책임 / 구조가 가리키는 경로)으로 두 파일을 봤다.

- **AGENTS.md 구조는 문제 없음** — 헤딩이 의도별로 분기하고("사용하려는 경우" vs "개발·수정·기여하려는 경우에만 clone"), 마지막 한 줄 요약이 다시 못을 박는다. README가 겪던 "헤딩이 틀린 경로를 가리키는" 문제가 없어 그대로 뒀다.
- **크로스 링크 이상 없음** — 두 파일 모두 README를 파일 단위로만 링크하고 앵커를 참조하지 않아, #26의 헤딩 변경 영향이 없다.
- **남은 문제는 도구 개수 표기** — 아래.

## 변경

**CLAUDE.md**

기존:
```
- 로컬 stdio: `koica_mcp_server.py`(도구 11개) / 원격 HTTP: `server_http.py`(읽기 8개)
```

`11개 대 8개`의 대비로 제시되고 원격에만 "읽기"라는 한정어가 붙어, 원격이 기능이 덜한 판본처럼 읽혔다. AGENTS.md가 이미 쓰고 있던 `11개 = 8개 + 3개` 덧셈 구조로 바꾸고 원격을 먼저 배치했다.

**AGENTS.md**

- 로컬 전용 3개에 "관리·개발용" 성격 표기
- `server_http.py`의 "읽기 8개"도 같은 기준으로 정리 — 8개가 부족한 게 아니라 상태 변경 도구를 노출하지 않는다는 사실을 살려서 서술

**공통**

두 파일 원격 섹션에 데이터 최신화 책임을 한 줄씩 추가했다. 기존에는 동기화 언급이 아예 없어, "데이터 어떻게 갱신하나"라는 질문을 받으면 README의 로컬 명령(`alio_sync.py` / `git pull`)으로 유입될 수 있었다.

## 확인

문서 변경만 있고 코드·데이터 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)