### PR TITLE
feat: Fly 대시보드용 MCP 사용량 메트릭

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # 애플리케이션 코드 (server_http → koica_mcp_server → koica_search / usage_stats 의존)
 # stats_cli.py: 소유자 전용 사용량 조회(공개 MCP엔 usage_stats 미노출, fly ssh로만 읽음)
-COPY koica_search.py semantic_search.py koica_mcp_server.py server_http.py usage_stats.py stats_cli.py alio_sync.py ./
+COPY koica_search.py semantic_search.py koica_mcp_server.py server_http.py usage_stats.py usage_metrics.py stats_cli.py alio_sync.py ./
 COPY tests/evaluate_semantic_quality.py ./tests/
 COPY LICENSE NOTICE /usr/share/doc/koica-reg-mcp/
 
@@ -51,6 +51,6 @@ RUN python3 -c "from mcp.server.fastmcp import FastMCP" \
 # 추론이 하나의 CPU 스레드만 쓰게 한다. 동시 세션 실행은 DenseEncoder 락이 직렬화한다.
 ENV KOICA_SEMANTIC_THREADS=1
 ENV PORT=8080
-EXPOSE 8080
+EXPOSE 8080 9091
 
 CMD ["python", "server_http.py"]

--- a/README.md
+++ b/README.md
@@ -280,6 +280,31 @@ python3 alio_sync.py --fresh  # 캐시 무시하고 처음부터
 
 ---
 
+## 운영 사용량 — Fly Metrics / Grafana
+
+원격 서버는 개인정보 없이 MCP 도구 호출 횟수만 `/data/usage.db`에 누적합니다.
+`usage_metrics.py`가 이 값을 내부 포트 `9091`의 Prometheus 형식으로 제공하고,
+`fly.toml`의 `[metrics]` 설정을 통해 Fly managed Prometheus가 수집합니다. 이 포트는
+공개 `http_service`에 연결되지 않으므로 외부 사용자는 통계를 직접 조회할 수 없습니다.
+
+Fly Dashboard에서 앱의 **Metrics → Grafana**를 연 뒤 아래 메트릭을 조회할 수 있습니다.
+
+| 메트릭 | 의미 |
+|---|---|
+| `koica_reg_mcp_calls_total` | 전체 MCP 도구 호출 누적 |
+| `koica_reg_mcp_tool_calls_total{tool="…"}` | 도구별 호출 누적 |
+| `koica_reg_mcp_weekly_calls{week_start="YYYY-MM-DD"}` | KST 월요일 기준 주차별 호출 |
+| `koica_reg_mcp_weekly_tool_calls{week_start="…",tool="…"}` | 주차·도구별 호출 |
+
+주차별 막대그래프는 Grafana에서 `koica_reg_mcp_weekly_calls`를 **Instant** 쿼리하고,
+범례를 `{{week_start}}`, 시각화를 Bar chart로 선택하면 됩니다. CLI 원자료 조회는
+`fly ssh console --app koica-reg-mcp --command "python3 /app/stats_cli.py"`를 사용합니다.
+
+> 이 값은 고유 사용자 수가 아니라 성공·실패를 포함한 MCP 도구 진입 횟수입니다.
+> 검색어, 응답, IP, 사용자·세션 식별자는 저장하지 않습니다.
+
+---
+
 ## 데이터 구조
 
 ```

--- a/fly.toml
+++ b/fly.toml
@@ -10,6 +10,8 @@ primary_region = 'nrt'
 # 이 env는 Fly 배포에만 존재하므로 로컬/도커 기본 실행에서는 집계가 꺼진다(no-op).
 [env]
   KOICA_STATS_DB = '/data/usage.db'
+  # Fly 내부 Prometheus scraper 전용 포트. 공개 http_service에는 연결하지 않는다.
+  KOICA_METRICS_PORT = '9091'
   # 주간 ALIO 변환 중에는 이 표식으로 ONNX 적재를 막고 키워드 검색으로 폴백한다.
   KOICA_SEMANTIC_PAUSE_FILE = '/data/semantic-search.paused'
 
@@ -28,6 +30,11 @@ primary_region = 'nrt'
   # ALIO 주간 동기화가 SSH로 실행되므로 도쿄 머신 1대는 상시 유지한다.
   min_machines_running = 1
   processes = ['app']
+
+# Fly managed Prometheus가 내부 포트에서 15초마다 사용량 메트릭을 수집한다.
+[metrics]
+  port = 9091
+  path = '/metrics'
 
 [[vm]]
   size = 'shared-cpu-1x'

--- a/server_http.py
+++ b/server_http.py
@@ -22,6 +22,7 @@ import os
 from mcp.server.fastmcp import FastMCP
 
 from koica_mcp_server import register_tools, SERVER_INSTRUCTIONS
+from usage_metrics import start_metrics_server
 
 # host/port 는 컨테이너/클라우드에서 주입된다. Fly.io 는 PORT 환경변수를 넘긴다.
 mcp = FastMCP(
@@ -36,4 +37,7 @@ register_tools(mcp, include_admin=False, include_questions=False)
 
 
 if __name__ == "__main__":
+    metrics_port = os.environ.get("KOICA_METRICS_PORT")
+    if metrics_port:
+        start_metrics_server(port=int(metrics_port))
     mcp.run(transport="streamable-http")

--- a/tests/test_usage_metrics.py
+++ b/tests/test_usage_metrics.py
@@ -1,0 +1,97 @@
+import urllib.error
+import urllib.request
+import unittest
+from unittest.mock import patch
+
+import usage_metrics
+
+
+SNAPSHOT = {
+    "enabled": True,
+    "total": 11,
+    "tools": [
+        {"tool": "search_regulation", "count": 7},
+        {"tool": 'quote"tool', "count": 4},
+    ],
+    "daily": [
+        {
+            "day": "2026-08-02",  # Sunday: week starting 2026-07-27
+            "total": 5,
+            "tools": {"search_regulation": 3, 'quote"tool': 2},
+            "by_language": {},
+        },
+        {
+            "day": "2026-08-03",  # Monday: new week
+            "total": 6,
+            "tools": {"search_regulation": 4, 'quote"tool': 2},
+            "by_language": {},
+        },
+    ],
+}
+
+
+class RenderMetricsTests(unittest.TestCase):
+    def test_renders_cumulative_and_kst_monday_week_buckets(self):
+        output = usage_metrics.render_metrics(SNAPSHOT)
+
+        self.assertIn("koica_reg_mcp_calls_total 11", output)
+        self.assertIn(
+            'koica_reg_mcp_tool_calls_total{tool="search_regulation"} 7',
+            output,
+        )
+        self.assertIn(
+            'koica_reg_mcp_tool_calls_total{tool="quote\\\"tool"} 4',
+            output,
+        )
+        self.assertIn(
+            'koica_reg_mcp_weekly_calls{week_start="2026-07-27"} 5',
+            output,
+        )
+        self.assertIn(
+            'koica_reg_mcp_weekly_calls{week_start="2026-08-03"} 6',
+            output,
+        )
+        self.assertTrue(output.endswith("# EOF\n"))
+
+    def test_reports_disabled_or_failed_stats_without_raising(self):
+        output = usage_metrics.render_metrics({
+            "enabled": False,
+            "error": "unavailable",
+            "tools": [],
+            "daily": [],
+        })
+
+        self.assertIn("koica_reg_mcp_stats_enabled 0", output)
+        self.assertIn("koica_reg_mcp_stats_read_error 1", output)
+        self.assertIn("koica_reg_mcp_calls_total 0", output)
+
+
+class MetricsHttpServerTests(unittest.TestCase):
+    def setUp(self):
+        render_patch = patch.object(
+            usage_metrics,
+            "render_metrics",
+            return_value="test_metric 1\n",
+        )
+        render_patch.start()
+        self.addCleanup(render_patch.stop)
+        try:
+            self.server = usage_metrics.start_metrics_server(host="127.0.0.1", port=0)
+        except PermissionError:
+            self.skipTest("test sandbox does not allow local socket binding")
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+    def test_metrics_endpoint_is_scrapeable(self):
+        with urllib.request.urlopen(f"{self.base_url}/metrics", timeout=2) as response:
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.read(), b"test_metric 1\n")
+            self.assertIn("version=0.0.4", response.headers["Content-Type"])
+
+    def test_other_paths_are_not_exposed(self):
+        with self.assertRaises(urllib.error.HTTPError) as raised:
+            urllib.request.urlopen(f"{self.base_url}/", timeout=2)
+        self.assertEqual(raised.exception.code, 404)

--- a/usage_metrics.py
+++ b/usage_metrics.py
@@ -1,0 +1,131 @@
+"""Fly Prometheus scraper용 KOICA MCP 사용량 메트릭.
+
+공개 MCP 포트(8080)와 분리된 내부 포트에서만 제공한다. 원본은 Fly 볼륨의
+``usage.db``이며, 검색어·IP·세션 같은 개인정보는 포함하지 않는다.
+"""
+
+from __future__ import annotations
+
+import datetime
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlsplit
+
+import usage_stats
+
+
+METRICS_PATH = "/metrics"
+
+
+def _label(value: object) -> str:
+    """Prometheus text exposition label 값을 이스케이프한다."""
+    return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+def _week_start(day: str) -> str:
+    date = datetime.date.fromisoformat(day)
+    return (date - datetime.timedelta(days=date.weekday())).isoformat()
+
+
+def _weekly_buckets(daily: list[dict]) -> tuple[dict[str, int], dict[tuple[str, str], int]]:
+    totals: dict[str, int] = {}
+    tools: dict[tuple[str, str], int] = {}
+    for row in daily:
+        week = _week_start(row["day"])
+        totals[week] = totals.get(week, 0) + int(row.get("total", 0))
+        for tool, count in row.get("tools", {}).items():
+            key = (week, str(tool))
+            tools[key] = tools.get(key, 0) + int(count)
+    return totals, tools
+
+
+def render_metrics(snap: dict | None = None) -> str:
+    """현재 SQLite 스냅샷을 Prometheus text exposition 형식으로 직렬화한다."""
+    if snap is None:
+        snap = usage_stats.snapshot()
+
+    enabled = bool(snap.get("enabled"))
+    read_error = bool(snap.get("error"))
+    tools = snap.get("tools", [])
+    daily = snap.get("daily", [])
+    total = sum(int(row.get("count", 0)) for row in tools)
+    weekly_totals, weekly_tools = _weekly_buckets(daily)
+
+    lines = [
+        "# HELP koica_reg_mcp_stats_enabled Whether persistent usage statistics are enabled.",
+        "# TYPE koica_reg_mcp_stats_enabled gauge",
+        f"koica_reg_mcp_stats_enabled {1 if enabled else 0}",
+        "# HELP koica_reg_mcp_stats_read_error Whether the latest SQLite statistics read failed.",
+        "# TYPE koica_reg_mcp_stats_read_error gauge",
+        f"koica_reg_mcp_stats_read_error {1 if read_error else 0}",
+        "# HELP koica_reg_mcp_calls_total Total MCP tool invocations recorded by the server.",
+        "# TYPE koica_reg_mcp_calls_total counter",
+        f"koica_reg_mcp_calls_total {total}",
+        "# HELP koica_reg_mcp_tool_calls_total MCP tool invocations by tool.",
+        "# TYPE koica_reg_mcp_tool_calls_total counter",
+    ]
+
+    for row in sorted(tools, key=lambda item: str(item.get("tool", ""))):
+        tool = _label(row.get("tool", "unknown"))
+        lines.append(f'koica_reg_mcp_tool_calls_total{{tool="{tool}"}} {int(row.get("count", 0))}')
+
+    lines.extend([
+        "# HELP koica_reg_mcp_weekly_calls MCP tool invocations grouped into KST Monday-start weeks.",
+        "# TYPE koica_reg_mcp_weekly_calls gauge",
+    ])
+    for week, count in sorted(weekly_totals.items()):
+        lines.append(f'koica_reg_mcp_weekly_calls{{week_start="{_label(week)}"}} {count}')
+
+    lines.extend([
+        "# HELP koica_reg_mcp_weekly_tool_calls MCP tool invocations by KST week and tool.",
+        "# TYPE koica_reg_mcp_weekly_tool_calls gauge",
+    ])
+    for (week, tool), count in sorted(weekly_tools.items()):
+        lines.append(
+            "koica_reg_mcp_weekly_tool_calls"
+            f'{{week_start="{_label(week)}",tool="{_label(tool)}"}} {count}'
+        )
+
+    lines.append("# EOF")
+    return "\n".join(lines) + "\n"
+
+
+class _MetricsHandler(BaseHTTPRequestHandler):
+    server_version = "koica-reg-metrics/1"
+
+    def _write_response(self, include_body: bool) -> None:
+        if urlsplit(self.path).path != METRICS_PATH:
+            body = b"not found\n"
+            self.send_response(404)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+        else:
+            body = render_metrics().encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if include_body:
+            self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        self._write_response(include_body=True)
+
+    def do_HEAD(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        self._write_response(include_body=False)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        # 15초마다 들어오는 Fly scrape가 애플리케이션 로그를 채우지 않게 한다.
+        return
+
+
+def start_metrics_server(host: str = "0.0.0.0", port: int = 9091) -> ThreadingHTTPServer:
+    """백그라운드 daemon thread에서 내부 Prometheus endpoint를 시작한다."""
+    server = ThreadingHTTPServer((host, port), _MetricsHandler)
+    server.daemon_threads = True
+    thread = threading.Thread(
+        target=server.serve_forever,
+        name="koica-prometheus-metrics",
+        daemon=True,
+    )
+    thread.start()
+    return server


### PR DESCRIPTION
## 변경 사항
- 운영 SQLite 누적값을 Prometheus 형식으로 내보내는 내부 전용 exporter 추가
- 도구별 누적 및 KST 월요일 기준 주차별 메트릭 제공
- Fly managed Prometheus가 내부 9091 포트를 수집하도록 설정
- 렌더링·주차 집계·HTTP endpoint 테스트와 운영 문서 추가

## 개인정보·노출 범위
- 검색어, IP, 사용자/세션 식별자는 수집하지 않음
- metrics 포트는 공개 http_service에 연결하지 않음

## 검증
- python -m unittest discover -s tests -v
- HTTP endpoint tests: 2 passed
- fly config validate --app koica-reg-mcp